### PR TITLE
fix: retry transient benchmark row fetches

### DIFF
--- a/internal/runner/benchmark.go
+++ b/internal/runner/benchmark.go
@@ -20,6 +20,8 @@ const (
 	defaultOpenClawBenchmarkSplit = "eval_holdout"
 	huggingFaceRowsEndpoint       = "https://datasets-server.huggingface.co/rows"
 	huggingFaceRowsPageSize       = 100
+	huggingFaceRowsMaxAttempts    = 4
+	huggingFaceRowsRetryBaseDelay = 500 * time.Millisecond
 )
 
 var openClawBenchmarkSplits = map[string]bool{
@@ -100,6 +102,7 @@ type OpenClawBundleFile struct {
 type HuggingFaceBenchmarkClient struct {
 	HTTPClient *http.Client
 	Endpoint   string
+	Sleep      func(time.Duration)
 }
 
 type huggingFaceRowsResponse struct {
@@ -326,7 +329,7 @@ func (client HuggingFaceBenchmarkClient) FetchOpenClawRows(dataset string, split
 				length = remaining
 			}
 		}
-		page, err := client.fetchOpenClawRowsPage(httpClient, endpoint, dataset, split, nextOffset, length)
+		page, err := client.fetchOpenClawRowsPageWithRetry(httpClient, endpoint, dataset, split, nextOffset, length)
 		if err != nil {
 			return nil, err
 		}
@@ -342,7 +345,29 @@ func (client HuggingFaceBenchmarkClient) FetchOpenClawRows(dataset string, split
 	return rows, nil
 }
 
-func (client HuggingFaceBenchmarkClient) fetchOpenClawRowsPage(httpClient *http.Client, endpoint string, dataset string, split string, offset int, length int) ([]OpenClawBenchmarkRow, error) {
+func (client HuggingFaceBenchmarkClient) fetchOpenClawRowsPageWithRetry(httpClient *http.Client, endpoint string, dataset string, split string, offset int, length int) ([]OpenClawBenchmarkRow, error) {
+	sleep := client.Sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	for attempt := 0; attempt < huggingFaceRowsMaxAttempts; attempt++ {
+		rows, transient, err := fetchOpenClawRowsPage(httpClient, endpoint, dataset, split, offset, length)
+		if err == nil {
+			return rows, nil
+		}
+		if !transient || attempt == huggingFaceRowsMaxAttempts-1 {
+			return nil, err
+		}
+		sleep(huggingFaceRowsRetryDelay(attempt))
+	}
+	return nil, errors.New("fetch benchmark rows failed")
+}
+
+func huggingFaceRowsRetryDelay(attempt int) time.Duration {
+	return huggingFaceRowsRetryBaseDelay * time.Duration(1<<attempt)
+}
+
+func fetchOpenClawRowsPage(httpClient *http.Client, endpoint string, dataset string, split string, offset int, length int) ([]OpenClawBenchmarkRow, bool, error) {
 	values := url.Values{}
 	values.Set("dataset", dataset)
 	values.Set("config", openClawBenchmarkConfig)
@@ -352,22 +377,30 @@ func (client HuggingFaceBenchmarkClient) fetchOpenClawRowsPage(httpClient *http.
 	requestURL := endpoint + "?" + values.Encode()
 	response, err := httpClient.Get(requestURL)
 	if err != nil {
-		return nil, err
+		return nil, true, fmt.Errorf("fetch benchmark rows: %w", err)
 	}
 	defer response.Body.Close()
 	var parsed huggingFaceRowsResponse
-	if err := json.NewDecoder(response.Body).Decode(&parsed); err != nil {
-		return nil, err
-	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_ = json.NewDecoder(response.Body).Decode(&parsed)
 		if parsed.Error != "" {
-			return nil, fmt.Errorf("fetch benchmark rows: %s", parsed.Error)
+			return nil, isTransientBenchmarkStatus(response.StatusCode), fmt.Errorf("fetch benchmark rows: %s", parsed.Error)
 		}
-		return nil, fmt.Errorf("fetch benchmark rows: HTTP %d", response.StatusCode)
+		return nil, isTransientBenchmarkStatus(response.StatusCode), fmt.Errorf("fetch benchmark rows: HTTP %d", response.StatusCode)
+	}
+	if err := json.NewDecoder(response.Body).Decode(&parsed); err != nil {
+		return nil, false, err
 	}
 	rows := make([]OpenClawBenchmarkRow, 0, len(parsed.Rows))
 	for _, row := range parsed.Rows {
 		rows = append(rows, row.Row)
 	}
-	return rows, nil
+	return rows, false, nil
+}
+
+func isTransientBenchmarkStatus(statusCode int) bool {
+	return statusCode == http.StatusRequestTimeout ||
+		statusCode == http.StatusTooEarly ||
+		statusCode == http.StatusTooManyRequests ||
+		statusCode >= http.StatusInternalServerError
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -201,6 +203,58 @@ func TestRunOpenClawBenchmarkMaterializesRowsAndRunsScanners(t *testing.T) {
 	}
 	if scanners.bundleContent != "echo ok\n" {
 		t.Fatalf("bundle file = %q", scanners.bundleContent)
+	}
+}
+
+func TestHuggingFaceBenchmarkClientRetriesTransientRowsFailures(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "<html>temporary upstream failure</html>")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"rows":[{"row":{"id":"row-1","skill_slug":"owner/demo","skill_version":"1.0.0","skill_md_content":"# Demo\n","skill_bundle_content":[],"clawscan_verdict":"clean","clawscan_confidence":"high","clawscan_model":"gpt-5","clawscan_summary":"ok","split":"eval_holdout"}}]}`)
+	}))
+	defer server.Close()
+
+	client := HuggingFaceBenchmarkClient{
+		Endpoint: server.URL,
+		Sleep:    func(time.Duration) {},
+	}
+	rows, err := client.FetchOpenClawRows(openClawBenchmarkID, defaultOpenClawBenchmarkSplit, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests != 3 {
+		t.Fatalf("requests = %d, want 3", requests)
+	}
+	if len(rows) != 1 || rows[0].ID != "row-1" {
+		t.Fatalf("rows = %#v", rows)
+	}
+}
+
+func TestHuggingFaceBenchmarkClientDoesNotRetryClientErrors(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"bad dataset request"}`)
+	}))
+	defer server.Close()
+
+	client := HuggingFaceBenchmarkClient{
+		Endpoint: server.URL,
+		Sleep:    func(time.Duration) {},
+	}
+	_, err := client.FetchOpenClawRows(openClawBenchmarkID, defaultOpenClawBenchmarkSplit, 0, 1)
+	if err == nil || err.Error() != "fetch benchmark rows: bad dataset request" {
+		t.Fatalf("err = %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Security Signals publish workflow can fail when Hugging Face's dataset rows endpoint briefly returns 502/429/5xx responses or transient network errors. That turns an upstream blip into a hard CI failure.

## Why This Change Was Made

The benchmark row fetch now retries transient rows-page failures with bounded exponential backoff, while client-side request errors still fail fast. Non-JSON upstream error bodies are handled as HTTP status errors instead of masking the real status behind a JSON decode failure.

## User Impact

Security Signals publishing should tolerate short Hugging Face outages without hiding real dataset/request problems.

## Evidence

- `go test ./internal/runner`
- `go test ./...`
