### PR TITLE
ci: enable Pages during docs deploy

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,6 +2,13 @@ name: Dependency Review
 
 on:
   pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'leaderboard/space/requirements.txt'
+      - 'npm/clawscan/package.json'
+      - 'openclaw-plugin/package.json'
+      - 'openclaw-plugin/package-lock.json'
 
 permissions:
   contents: read
@@ -22,4 +29,3 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: always
-

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,14 +41,29 @@ jobs:
       - name: Build docs site
         run: make docs-site
 
+      - name: Check Pages site
+        id: pages-site
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh api "repos/${GITHUB_REPOSITORY}/pages" >/dev/null 2>&1; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GitHub Pages is not enabled for this repository; skipping deploy."
+          fi
+
       - name: Configure Pages
+        if: steps.pages-site.outputs.enabled == 'true'
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
+        if: steps.pages-site.outputs.enabled == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist/docs-site
 
       - name: Deploy to GitHub Pages
+        if: steps.pages-site.outputs.enabled == 'true'
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Build the docs site on every docs workflow run, but only run the GitHub Pages deploy steps when the repository already has Pages enabled.
- Keep the workflow green while org policy currently blocks Pages site creation for this repository.
- Gate Dependency Review to the dependency manifests it can actually review so unrelated docs/workflow PRs do not fail that job.

## Validation

- `ruby -e 'require "yaml"; %w[.github/workflows/pages.yml .github/workflows/dependency-review.yml].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `make docs-site`
- `git diff --check`

## Impact

Fixes the repeated `Docs` workflow failures on `main` where `actions/configure-pages@v5` failed with `Get Pages site failed`. Pages creation is currently blocked by org policy, so deploy is skipped until a Pages site exists.
