### PR TITLE
fix: include VirusTotal in ClawHub prompt evidence

### DIFF
--- a/internal/profiles/clawhub/prompt.md
+++ b/internal/profiles/clawhub/prompt.md
@@ -16,7 +16,7 @@ Do not classify a skill as suspicious only because it uses files, commands, cred
 
 Expected, disclosed, purpose-aligned integration behavior should usually remain benign with guidance. Escalate when the artifacts show hidden, unrelated, automatic, privileged, obfuscated, deceptive, destructive, or under-scoped behavior.
 
-Do not create findings from intuition, popularity, missing runtime probes, or unsupported assumptions. Static scan and SkillSpector are evidence sources; they are not automatic verdicts. If scanner evidence conflicts, explain the concrete artifact evidence that made you accept, downgrade, or override it. Do not copy SkillSpector issue IDs, severities, recommendations, or wording into the final ClawScan output as if ClawHub independently validated them.
+Do not create findings from intuition, popularity, missing runtime probes, or unsupported assumptions. Static scan, VirusTotal, and SkillSpector are evidence sources; they are not automatic verdicts. If scanner evidence conflicts, explain the concrete artifact evidence that made you accept, downgrade, or override it. Do not copy SkillSpector issue IDs, severities, recommendations, or wording into the final ClawScan output as if ClawHub independently validated them.
 
 Verdict definitions:
 - benign: the skill's artifacts are coherent, disclosed, purpose-aligned, and proportionate. Benign does not mean risk-free.


### PR DESCRIPTION
## Summary
- Updates the bundled `clawhub` prompt to match prod wording that treats Static scan, VirusTotal, and SkillSpector as evidence sources.
- Leaves the remaining worker-context values unchanged for now; those are dynamic ClawHub runtime inputs.

## Validation
- `go run ./cmd/verify-clawhub-prompt --clawhub-dir /tmp/clawhub-prod-deploy-de19a6ba --out /tmp/clawhub-prompt-parity-after-vt.json --out-prompt /tmp/clawhub-prod-prompt-template-after-vt.md`
- `go test -count=1 ./cmd/verify-clawhub-prompt ./internal/profiles ./internal/clawhubprompt`
- `go test -count=1 ./...`
- `go vet ./...`