### PR TITLE
feat(runner): support OpenClaw plugins across the ClawHub profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ clawscan ./my-skill --profile clawhub
 ```
 
 The same profile accepts an explicit OpenClaw plugin directory (or its
-`openclaw.plugin.json` manifest), runs all three scanners, and renders the
+`openclaw.plugin.json` manifest), runs both scanners, and renders the
 bundled judge prompt with `packageRelease` target context.
 
 Inspect the resolved profile catalog, including the nearest project

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ ClawScan turns that approach into a repeatable CLI. It includes a built-in `claw
 
 | Command family | Use |
 | --- | --- |
-| `clawscan <target> --scanner <id>` | Run one or more scanners against an explicit target. Omit `<target>` to scan child skill directories under `./skills`. |
+| `clawscan <target> --scanner <id>` | Run one or more scanners against an explicit skill or OpenClaw plugin target. Omit `<target>` to scan child skill directories under `./skills`; plugins are never auto-discovered. |
 | `clawscan scanners [list\|<scanner-id>]` | Discover supported scanner IDs, required env vars, upstream links, descriptions, and install guidance. |
 | `clawscan profiles [-v]` | Inspect built-in plus nearest project-local profiles; `-v` prints the resolved profile catalog as YAML. |
 | `clawscan benchmark [list\|<benchmark-id>]` | Discover or run supported benchmarks through a selected scanner/profile/judge setup. |

--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ clawscan scanners skillspector
 | `agentverus` | AgentVerus | [repo](https://github.com/agentverus/agentverus-scanner) | Local file or directory scanner invoked through agentverus-scanner. | none | `npm install --save-dev agentverus-scanner` |
 | `aig` | Tencent AI-Infra-Guard | [repo](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) | Tencent Zhuque Lab's local directory scanner invoked through `aig-skill-scan`. Produces SARIF 2.1.0 with SkillTrustBench T01-T09 evidence. | `LLM_API_KEY` or `OPENAI_API_KEY`<br><details><summary>Optional config</summary><code>DEFAULT_MODEL</code>, <code>DEFAULT_BASE_URL</code>, <code>DEFAULT_MODEL_CONTEXT_WINDOW</code>, <code>LOG_LEVEL</code>.</details> | `pip install aig-skill-scan` |
 | `cisco` | Cisco AI Defense skill-scanner | [repo](https://github.com/cisco-ai-defense/skill-scanner) | Local file or directory scanner invoked through `skill-scanner` with JSON report output. Optional upstream env vars enable LLM, VirusTotal, and Cisco AI Defense analyzers. | none<br><details><summary>Optional config</summary><code>SKILL_SCANNER_LLM_API_KEY</code>, <code>SKILL_SCANNER_LLM_PROVIDER</code>, <code>SKILL_SCANNER_LLM_MODEL</code>, <code>SKILL_SCANNER_LLM_BASE_URL</code>, <code>SKILL_SCANNER_LLM_USER</code>, <code>SKILL_SCANNER_LLM_API_VERSION</code>, <code>SKILL_SCANNER_LLM_FORCE_JSON_OBJECT</code>, <code>SKILL_SCANNER_META_LLM_API_KEY</code>, <code>SKILL_SCANNER_META_LLM_MODEL</code>, <code>SKILL_SCANNER_META_LLM_BASE_URL</code>, <code>SKILL_SCANNER_META_LLM_API_VERSION</code>, <code>AWS_PROFILE</code>, <code>AWS_REGION</code>, <code>GOOGLE_APPLICATION_CREDENTIALS</code>, <code>VIRUSTOTAL_API_KEY</code>, <code>AI_DEFENSE_API_KEY</code>, <code>AI_DEFENSE_API_URL</code>.</details> | `uv pip install cisco-ai-skill-scanner` |
-| `clawscan-static` | ClawScan Static | [repo](https://github.com/openclaw/clawscan) | Built-in deterministic text scanner for high-signal risky skill patterns. | none | skipped; built in |
-| `skillspector` | NVIDIA SkillSpector | [repo](https://github.com/NVIDIA/skillspector) | Local file or directory scanner. Uses LLM mode when provider env vars are set; otherwise runs with `--no-llm`. | none<br><details><summary>Optional config</summary><code>SKILLSPECTOR_PROVIDER</code>, <code>SKILLSPECTOR_MODEL</code>, <code>SKILLSPECTOR_MODEL_REGISTRY</code>, <code>SKILLSPECTOR_LOG_LEVEL</code>, <code>SKILLSPECTOR_SSL_VERIFY</code>, <code>NVIDIA_INFERENCE_KEY</code>, <code>OPENAI_API_KEY</code>, <code>OPENAI_BASE_URL</code>, <code>ANTHROPIC_API_KEY</code>, <code>ANTHROPIC_PROXY_ENDPOINT_URL</code>, <code>ANTHROPIC_PROXY_API_KEY</code>, <code>ANTHROPIC_PROXY_API_VERSION</code>.</details> | `uv tool install git+https://github.com/NVIDIA/skillspector.git` |
+| `clawscan-static` | ClawScan Static | [repo](https://github.com/openclaw/clawscan) | Built-in deterministic text scanner for high-signal risky skill and OpenClaw plugin patterns. | none | skipped; built in |
+| `skillspector` | NVIDIA SkillSpector | [repo](https://github.com/NVIDIA/skillspector) | Local skill or OpenClaw plugin file/directory scanner. Uses LLM mode when provider env vars are set; otherwise runs with `--no-llm`. | none<br><details><summary>Optional config</summary><code>SKILLSPECTOR_PROVIDER</code>, <code>SKILLSPECTOR_MODEL</code>, <code>SKILLSPECTOR_MODEL_REGISTRY</code>, <code>SKILLSPECTOR_LOG_LEVEL</code>, <code>SKILLSPECTOR_SSL_VERIFY</code>, <code>NVIDIA_INFERENCE_KEY</code>, <code>OPENAI_API_KEY</code>, <code>OPENAI_BASE_URL</code>, <code>ANTHROPIC_API_KEY</code>, <code>ANTHROPIC_PROXY_ENDPOINT_URL</code>, <code>ANTHROPIC_PROXY_API_KEY</code>, <code>ANTHROPIC_PROXY_API_VERSION</code>.</details> | `uv tool install git+https://github.com/NVIDIA/skillspector.git` |
 | `snyk` | Snyk Agent Scan | [repo](https://github.com/snyk/agent-scan) | Local skill scanner invoked through `uvx snyk-agent-scan`. | `SNYK_TOKEN` | verifies `uvx` launcher |
 | `socket` | Socket CLI | [repo](https://github.com/SocketDev/socket-cli) | Local file or directory scanner using Socket's public CLI full-scan path. | `SOCKET_CLI_API_TOKEN` | `npm install -g socket` |
-| `virustotal` | VirusTotal API | [docs](https://docs.virustotal.com/reference/file) | API-backed single local file hash lookup. Directories return a skipped result. | `VIRUSTOTAL_API_KEY` | skipped; API-backed |
+| `virustotal` | VirusTotal API | [docs](https://docs.virustotal.com/reference/file) | API-backed local file hash lookup. Skill and OpenClaw plugin directories are scanned as deterministic ZIP archives. | `VIRUSTOTAL_API_KEY` | skipped; API-backed |
 
 Starting in `v0.1.2`, the built-in `aig` scanner uses Tencent's local
 `aig-skill-scan` package instead of the legacy A.I.G Docker/API service.
@@ -168,6 +168,10 @@ judge harness:
 ```bash
 clawscan ./my-skill --profile clawhub
 ```
+
+The same profile accepts an explicit OpenClaw plugin directory (or its
+`openclaw.plugin.json` manifest), runs all three scanners, and renders the
+bundled judge prompt with `packageRelease` target context.
 
 Inspect the resolved profile catalog, including the nearest project
 `.clawscan.yml` / `.clawscan.yaml` when present:

--- a/cmd/clawscan/main.go
+++ b/cmd/clawscan/main.go
@@ -624,6 +624,9 @@ Target notes:
   No target with --scanner, --profile, or --config scans child skill directories under ./skills.
   Plain clawscan without --scanner, --profile, or --config is invalid.
   Most scanners use a local skill file or directory target.
+  A directory holding openclaw.plugin.json is scanned as an OpenClaw plugin.
+  The built-in clawscan-static scanner analyzes plugins; skill-only scanners return a skipped result.
+  Plugins are never auto-discovered; pass the plugin directory explicitly.
   Socket runs the public Socket CLI full-scan path over local dependency manifests.
 
 Judge summary:

--- a/cmd/clawscan/main.go
+++ b/cmd/clawscan/main.go
@@ -625,7 +625,7 @@ Target notes:
   Plain clawscan without --scanner, --profile, or --config is invalid.
   Most scanners use a local skill file or directory target.
   A directory holding openclaw.plugin.json is scanned as an OpenClaw plugin.
-  The clawhub profile runs SkillSpector, VirusTotal, and clawscan-static for plugins as it does for skills.
+  The clawhub profile runs SkillSpector and clawscan-static for plugins as it does for skills.
   Other skill-only scanners return a skipped result for plugins.
   Plugins are never auto-discovered; pass the plugin directory explicitly.
   Socket runs the public Socket CLI full-scan path over local dependency manifests.

--- a/cmd/clawscan/main.go
+++ b/cmd/clawscan/main.go
@@ -625,7 +625,8 @@ Target notes:
   Plain clawscan without --scanner, --profile, or --config is invalid.
   Most scanners use a local skill file or directory target.
   A directory holding openclaw.plugin.json is scanned as an OpenClaw plugin.
-  The built-in clawscan-static scanner analyzes plugins; skill-only scanners return a skipped result.
+  The clawhub profile runs SkillSpector, VirusTotal, and clawscan-static for plugins as it does for skills.
+  Other skill-only scanners return a skipped result for plugins.
   Plugins are never auto-discovered; pass the plugin directory explicitly.
   Socket runs the public Socket CLI full-scan path over local dependency manifests.
 

--- a/cmd/clawscan/main_test.go
+++ b/cmd/clawscan/main_test.go
@@ -387,6 +387,71 @@ func TestRunCommandWritesArtifact(t *testing.T) {
 	}
 }
 
+func TestRunCommandScansPluginTargetAndSkipsSkillOnlyScanner(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "probe-plugin")
+	writePlugin(t, target, "probe-plugin")
+	out := filepath.Join(dir, "run.json")
+
+	stdout := captureStdout(t, func() {
+		if err := run([]string{target, "--scanner", "clawscan-static", "--scanner", "skillspector", "--output", out}, []string{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(stdout, "scanner_completed: 1") {
+		t.Fatalf("summary missing completed scanner:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "scanner_skipped: 1") {
+		t.Fatalf("summary missing skipped scanner:\n%s", stdout)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var artifact struct {
+		Target struct {
+			Kind         string `json:"kind"`
+			ID           string `json:"id"`
+			ResolvedPath string `json:"resolvedPath"`
+		} `json:"target"`
+		Scanners map[string]struct {
+			Status string `json:"status"`
+			Error  string `json:"error"`
+		} `json:"scanners"`
+	}
+	if err := json.Unmarshal(data, &artifact); err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Target.Kind != "plugin" {
+		t.Fatalf("target kind = %q", artifact.Target.Kind)
+	}
+	if artifact.Target.ID != "probe-plugin" {
+		t.Fatalf("target id = %q", artifact.Target.ID)
+	}
+	static := artifact.Scanners["clawscan-static"]
+	if static.Status != "completed" {
+		t.Fatalf("clawscan-static result = %#v", static)
+	}
+	spector := artifact.Scanners["skillspector"]
+	if spector.Status != "skipped" || !strings.Contains(spector.Error, "does not support plugin targets") {
+		t.Fatalf("skillspector result = %#v", spector)
+	}
+}
+
+func TestRunCommandDoesNotAutoDiscoverPlugins(t *testing.T) {
+	dir := t.TempDir()
+	// A plugin placed under ./skills without a SKILL.md must not be discovered,
+	// so plugin auto-discovery cannot silently scan arbitrary package dirs.
+	writePlugin(t, filepath.Join(dir, "skills", "probe-plugin"), "probe-plugin")
+	t.Chdir(dir)
+
+	err := run([]string{"--scanner", "clawscan-static"}, []string{})
+	if err == nil || !strings.Contains(err.Error(), "No valid skills found") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
 func TestRunCommandWritesDefaultOutputAndPrintsKeyValueSummary(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "skill")
@@ -736,6 +801,20 @@ func writeSkill(t *testing.T, dir string, content string) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writePlugin(t *testing.T, dir string, id string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{"id":"` + id + `","name":"Probe Plugin","contracts":{"tools":["probe_tool"]}}`
+	if err := os.WriteFile(filepath.Join(dir, "openclaw.plugin.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.js"), []byte("// synthetic probe\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/clawscan/main_test.go
+++ b/cmd/clawscan/main_test.go
@@ -387,22 +387,32 @@ func TestRunCommandWritesArtifact(t *testing.T) {
 	}
 }
 
-func TestRunCommandScansPluginTargetAndSkipsSkillOnlyScanner(t *testing.T) {
+func TestRunCommandScansPluginTargetWithClawHubScanners(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "probe-plugin")
 	writePlugin(t, target, "probe-plugin")
 	out := filepath.Join(dir, "run.json")
+	skillSpectorFixture := filepath.Join(dir, "skillspector.json")
+	writeFile(t, skillSpectorFixture, `{"status":"clean","findings":[]}`)
+	virusTotalFixture := filepath.Join(dir, "virustotal.json")
+	writeFile(t, virusTotalFixture, `{"status":"clean","source":"engines"}`)
 
 	stdout := captureStdout(t, func() {
-		if err := run([]string{target, "--scanner", "clawscan-static", "--scanner", "skillspector", "--output", out}, []string{}); err != nil {
+		if err := run([]string{
+			target,
+			"--scanner", "skillspector", "--scanner-result", "skillspector=" + skillSpectorFixture,
+			"--scanner", "virustotal", "--scanner-result", "virustotal=" + virusTotalFixture,
+			"--scanner", "clawscan-static",
+			"--output", out,
+		}, []string{}); err != nil {
 			t.Fatal(err)
 		}
 	})
-	if !strings.Contains(stdout, "scanner_completed: 1") {
+	if !strings.Contains(stdout, "scanner_completed: 3") {
 		t.Fatalf("summary missing completed scanner:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "scanner_skipped: 1") {
-		t.Fatalf("summary missing skipped scanner:\n%s", stdout)
+	if !strings.Contains(stdout, "scanner_skipped: 0") {
+		t.Fatalf("summary has unexpected skipped count:\n%s", stdout)
 	}
 
 	data, err := os.ReadFile(out)
@@ -429,13 +439,10 @@ func TestRunCommandScansPluginTargetAndSkipsSkillOnlyScanner(t *testing.T) {
 	if artifact.Target.ID != "probe-plugin" {
 		t.Fatalf("target id = %q", artifact.Target.ID)
 	}
-	static := artifact.Scanners["clawscan-static"]
-	if static.Status != "completed" {
-		t.Fatalf("clawscan-static result = %#v", static)
-	}
-	spector := artifact.Scanners["skillspector"]
-	if spector.Status != "skipped" || !strings.Contains(spector.Error, "does not support plugin targets") {
-		t.Fatalf("skillspector result = %#v", spector)
+	for _, scanner := range []string{"skillspector", "virustotal", "clawscan-static"} {
+		if result := artifact.Scanners[scanner]; result.Status != "completed" {
+			t.Fatalf("%s result = %#v", scanner, result)
+		}
 	}
 }
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -9,7 +9,7 @@ clawscan ./my-skill --profile clawhub
 ```
 
 The same profile accepts an explicit OpenClaw plugin directory (or its
-`openclaw.plugin.json` manifest), runs all three scanners, and renders the
+`openclaw.plugin.json` manifest), runs both scanners, and renders the
 bundled judge prompt with `packageRelease` target context.
 
 Inspect the resolved profile catalog, including the nearest project

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -8,6 +8,10 @@ judge harness:
 clawscan ./my-skill --profile clawhub
 ```
 
+The same profile accepts an explicit OpenClaw plugin directory (or its
+`openclaw.plugin.json` manifest), runs all three scanners, and renders the
+bundled judge prompt with `packageRelease` target context.
+
 Inspect the resolved profile catalog, including the nearest project
 `.clawscan.yml` / `.clawscan.yaml` when present:
 

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -33,7 +33,8 @@ The built-in `clawhub` profile runs `skillspector`, `virustotal`, and
 that assume skill layouts return an explicit `skipped` result naming the
 unsupported kind, and adapters can opt in per kind as upstream tools add plugin
 support. A directory carrying both `SKILL.md` and `openclaw.plugin.json` is
-rejected as ambiguous rather than guessed.
+rejected as ambiguous rather than guessed; point Clawscan directly at the
+desired manifest to disambiguate a valid dual-layout package.
 
 Plugin targets are never auto-discovered. Zero-target discovery still scans only
 child skill directories under `./skills`; pass a plugin directory explicitly to

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -28,11 +28,12 @@ the result in the artifact `target.kind` field:
 | `plugin` | directory (or manifest file) holds `openclaw.plugin.json` | OpenClaw plugin. The stable manifest `id` is recorded in `target.id`; host paths are never used as identity. |
 | `url` | `http`/`https` input | API-backed and static scanners skip URLs. |
 
-The built-in `clawscan-static` scanner analyzes `plugin` targets; scanners that
-assume skill layouts return an explicit `skipped` result naming the unsupported
-kind, and adapters can opt in per kind as upstream tools add plugin support. A
-directory carrying both `SKILL.md` and `openclaw.plugin.json` is rejected as
-ambiguous rather than guessed.
+The built-in `clawhub` profile runs `skillspector`, `virustotal`, and
+`clawscan-static` for `plugin` targets as it does for skills. Other scanners
+that assume skill layouts return an explicit `skipped` result naming the
+unsupported kind, and adapters can opt in per kind as upstream tools add plugin
+support. A directory carrying both `SKILL.md` and `openclaw.plugin.json` is
+rejected as ambiguous rather than guessed.
 
 Plugin targets are never auto-discovered. Zero-target discovery still scans only
 child skill directories under `./skills`; pass a plugin directory explicitly to
@@ -53,11 +54,11 @@ guessed at.
 | `agentverus` | AgentVerus | [repo](https://github.com/agentverus/agentverus-scanner) | Local file or directory scanner invoked through agentverus-scanner. | none | `npm install --save-dev agentverus-scanner` |
 | `aig` | Tencent AI-Infra-Guard | [repo](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) | Tencent Zhuque Lab's local directory scanner invoked through `aig-skill-scan`. Produces SARIF 2.1.0 with SkillTrustBench T01-T09 evidence. | `LLM_API_KEY` or `OPENAI_API_KEY`<br><details><summary>Optional config</summary><code>DEFAULT_MODEL</code>, <code>DEFAULT_BASE_URL</code>, <code>DEFAULT_MODEL_CONTEXT_WINDOW</code>, <code>LOG_LEVEL</code>.</details> | `pip install aig-skill-scan` |
 | `cisco` | Cisco AI Defense skill-scanner | [repo](https://github.com/cisco-ai-defense/skill-scanner) | Local file or directory scanner invoked through `skill-scanner` with JSON report output. Optional upstream env vars enable LLM, VirusTotal, and Cisco AI Defense analyzers. | none<br><details><summary>Optional config</summary><code>SKILL_SCANNER_LLM_API_KEY</code>, <code>SKILL_SCANNER_LLM_PROVIDER</code>, <code>SKILL_SCANNER_LLM_MODEL</code>, <code>SKILL_SCANNER_LLM_BASE_URL</code>, <code>SKILL_SCANNER_LLM_USER</code>, <code>SKILL_SCANNER_LLM_API_VERSION</code>, <code>SKILL_SCANNER_LLM_FORCE_JSON_OBJECT</code>, <code>SKILL_SCANNER_META_LLM_API_KEY</code>, <code>SKILL_SCANNER_META_LLM_MODEL</code>, <code>SKILL_SCANNER_META_LLM_BASE_URL</code>, <code>SKILL_SCANNER_META_LLM_API_VERSION</code>, <code>AWS_PROFILE</code>, <code>AWS_REGION</code>, <code>GOOGLE_APPLICATION_CREDENTIALS</code>, <code>VIRUSTOTAL_API_KEY</code>, <code>AI_DEFENSE_API_KEY</code>, <code>AI_DEFENSE_API_URL</code>.</details> | `uv pip install cisco-ai-skill-scanner` |
-| `clawscan-static` | ClawScan Static | [repo](https://github.com/openclaw/clawscan) | Built-in deterministic text scanner for high-signal risky skill patterns. | none | skipped; built in |
-| `skillspector` | NVIDIA SkillSpector | [repo](https://github.com/NVIDIA/skillspector) | Local file or directory scanner. Uses LLM mode when provider env vars are set; otherwise runs with `--no-llm`. | none<br><details><summary>Optional config</summary><code>SKILLSPECTOR_PROVIDER</code>, <code>SKILLSPECTOR_MODEL</code>, <code>SKILLSPECTOR_MODEL_REGISTRY</code>, <code>SKILLSPECTOR_LOG_LEVEL</code>, <code>SKILLSPECTOR_SSL_VERIFY</code>, <code>NVIDIA_INFERENCE_KEY</code>, <code>OPENAI_API_KEY</code>, <code>OPENAI_BASE_URL</code>, <code>ANTHROPIC_API_KEY</code>, <code>ANTHROPIC_PROXY_ENDPOINT_URL</code>, <code>ANTHROPIC_PROXY_API_KEY</code>, <code>ANTHROPIC_PROXY_API_VERSION</code>.</details> | `uv tool install git+https://github.com/NVIDIA/skillspector.git` |
+| `clawscan-static` | ClawScan Static | [repo](https://github.com/openclaw/clawscan) | Built-in deterministic text scanner for high-signal risky skill and OpenClaw plugin patterns. | none | skipped; built in |
+| `skillspector` | NVIDIA SkillSpector | [repo](https://github.com/NVIDIA/skillspector) | Local skill or OpenClaw plugin file/directory scanner. Uses LLM mode when provider env vars are set; otherwise runs with `--no-llm`. | none<br><details><summary>Optional config</summary><code>SKILLSPECTOR_PROVIDER</code>, <code>SKILLSPECTOR_MODEL</code>, <code>SKILLSPECTOR_MODEL_REGISTRY</code>, <code>SKILLSPECTOR_LOG_LEVEL</code>, <code>SKILLSPECTOR_SSL_VERIFY</code>, <code>NVIDIA_INFERENCE_KEY</code>, <code>OPENAI_API_KEY</code>, <code>OPENAI_BASE_URL</code>, <code>ANTHROPIC_API_KEY</code>, <code>ANTHROPIC_PROXY_ENDPOINT_URL</code>, <code>ANTHROPIC_PROXY_API_KEY</code>, <code>ANTHROPIC_PROXY_API_VERSION</code>.</details> | `uv tool install git+https://github.com/NVIDIA/skillspector.git` |
 | `snyk` | Snyk Agent Scan | [repo](https://github.com/snyk/agent-scan) | Local skill scanner invoked through `uvx snyk-agent-scan`. | `SNYK_TOKEN` | verifies `uvx` launcher |
 | `socket` | Socket CLI | [repo](https://github.com/SocketDev/socket-cli) | Local file or directory scanner using Socket's public CLI full-scan path. | `SOCKET_CLI_API_TOKEN` | `npm install -g socket` |
-| `virustotal` | VirusTotal API | [docs](https://docs.virustotal.com/reference/file) | API-backed single local file hash lookup. Directories return a skipped result. | `VIRUSTOTAL_API_KEY` | skipped; API-backed |
+| `virustotal` | VirusTotal API | [docs](https://docs.virustotal.com/reference/file) | API-backed local file hash lookup. Skill and OpenClaw plugin directories are scanned as deterministic ZIP archives. | `VIRUSTOTAL_API_KEY` | skipped; API-backed |
 
 ### AIG migration
 

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -28,8 +28,9 @@ the result in the artifact `target.kind` field:
 | `plugin` | directory (or manifest file) holds `openclaw.plugin.json` | OpenClaw plugin. The stable manifest `id` is recorded in `target.id`; host paths are never used as identity. |
 | `url` | `http`/`https` input | API-backed and static scanners skip URLs. |
 
-The built-in `clawhub` profile runs `skillspector`, `virustotal`, and
-`clawscan-static` for `plugin` targets as it does for skills. Other scanners
+The built-in `clawhub` profile runs `skillspector` and `clawscan-static` for
+`plugin` targets as it does for skills. VirusTotal and Socket also support
+plugins when selected explicitly or through a custom profile. Other scanners
 that assume skill layouts return an explicit `skipped` result naming the
 unsupported kind, and adapters can opt in per kind as upstream tools add plugin
 support. A directory carrying both `SKILL.md` and `openclaw.plugin.json` is
@@ -41,10 +42,9 @@ child skill directories under `./skills`; pass a plugin directory explicitly to
 avoid silently scanning arbitrary package directories. Pointing Clawscan at an
 `openclaw.plugin.json` file scans the surrounding plugin directory.
 
-Plugin ids follow OpenClaw's install grammar, including `@scope/name` ids. The
-manifest must parse as strict JSON in this version; JSON5-only manifests
-(comments, trailing commas) are rejected with an explicit error rather than
-guessed at.
+Plugin ids follow OpenClaw's install grammar, including `@scope/name` ids.
+Manifests accept the same JSON5 syntax as OpenClaw, including comments, trailing
+commas, single-quoted strings, and unquoted keys.
 
 ## Available scanners
 

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -17,6 +17,33 @@ clawscan scanners
 clawscan scanners skillspector
 ```
 
+## Target kinds
+
+Clawscan classifies each explicit target before dispatching scanners and records
+the result in the artifact `target.kind` field:
+
+| Kind | Detected when | Notes |
+| --- | --- | --- |
+| `skill` | default for local files and directories | Historical behavior; a directory usually holds `SKILL.md`. |
+| `plugin` | directory (or manifest file) holds `openclaw.plugin.json` | OpenClaw plugin. The stable manifest `id` is recorded in `target.id`; host paths are never used as identity. |
+| `url` | `http`/`https` input | API-backed and static scanners skip URLs. |
+
+The built-in `clawscan-static` scanner analyzes `plugin` targets; scanners that
+assume skill layouts return an explicit `skipped` result naming the unsupported
+kind, and adapters can opt in per kind as upstream tools add plugin support. A
+directory carrying both `SKILL.md` and `openclaw.plugin.json` is rejected as
+ambiguous rather than guessed.
+
+Plugin targets are never auto-discovered. Zero-target discovery still scans only
+child skill directories under `./skills`; pass a plugin directory explicitly to
+avoid silently scanning arbitrary package directories. Pointing Clawscan at an
+`openclaw.plugin.json` file scans the surrounding plugin directory.
+
+Plugin ids follow OpenClaw's install grammar, including `@scope/name` ids. The
+manifest must parse as strict JSON in this version; JSON5-only manifests
+(comments, trailing commas) are rejected with an explicit error rather than
+guessed at.
+
 ## Available scanners
 
 > **Want to add your scanner to the list?** Follow the guide in [docs/scanners.md](docs/scanners.md#adding-a-built-in-scanner-adapter)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/openclaw/clawscan
 
 go 1.26.1
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/alchemy/json5 v0.2.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/alchemy/json5 v0.2.0 h1:M8hmUpCyGlzdiWaxY4RI/rDcLAlFTtjB6j49eUpk+FE=
+github.com/alchemy/json5 v0.2.0/go.mod h1:kVE7UoCjGVIlxOXFCzKn6T34nyC/OctNTNG81MLOqiw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1000,7 +1000,8 @@ func targetFilePriority(root string, path string) int {
 	if err != nil {
 		rel = path
 	}
-	if strings.EqualFold(filepath.ToSlash(rel), "SKILL.md") {
+	normalized := filepath.ToSlash(rel)
+	if strings.EqualFold(normalized, skillManifestName) || strings.EqualFold(normalized, pluginManifestName) {
 		return 0
 	}
 	return 1
@@ -1472,7 +1473,11 @@ func clawHubSystemPrompt(source string) string {
 func clawHubPromptJob(artifact Artifact, context clawHubContext) clawhubprompt.Job {
 	targetKind := context.TargetKind
 	if targetKind == "" {
-		targetKind = "skillVersion"
+		if artifact.Target.Kind == targetKindPlugin {
+			targetKind = "packageRelease"
+		} else {
+			targetKind = "skillVersion"
+		}
 	}
 	source := context.Source
 	if source == "" {
@@ -1482,7 +1487,7 @@ func clawHubPromptJob(artifact Artifact, context clawHubContext) clawhubprompt.J
 	if context.HasMaliciousSignal != nil {
 		hasMaliciousSignal = *context.HasMaliciousSignal
 	}
-	return clawhubprompt.Job{
+	job := clawhubprompt.Job{
 		Job: clawhubprompt.JobMetadata{
 			TargetKind:         targetKind,
 			Source:             source,
@@ -1490,11 +1495,17 @@ func clawHubPromptJob(artifact Artifact, context clawHubContext) clawhubprompt.J
 		},
 		Target: clawhubprompt.Target{
 			TrustedOpenClawPlugin: context.TrustedOpenClawPlugin,
-			Version: &clawhubprompt.Version{
-				SkillSpectorAnalysis: nil,
-			},
 		},
 	}
+	evidence := &clawhubprompt.Version{
+		SkillSpectorAnalysis: nil,
+	}
+	if targetKind == "packageRelease" {
+		job.Target.Release = evidence
+	} else {
+		job.Target.Version = evidence
+	}
+	return job
 }
 
 func clawHubAIGAnalysis(artifact Artifact) any {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -396,6 +396,8 @@ func Run(opts Options, ctx RunContext) (Artifact, error) {
 			CommandRunner:        commandRunner,
 			Env:                  env,
 			Profile:              opts.Profile,
+			TargetKind:           target.kind,
+			TargetID:             target.id,
 			SandboxMode:          scannerSandboxMode,
 			SkillSpectorCommand:  ctx.SkillSpectorCommand,
 			VirusTotalHTTPClient: ctx.VirusTotalHTTPClient,
@@ -778,7 +780,7 @@ func ResolveTargetInputs(opts Options, cwd string) ([]string, error) {
 			continue
 		}
 		skillFile := filepath.Join(skillsDir, entry.Name(), "SKILL.md")
-		if info, err := os.Stat(skillFile); err == nil && !info.IsDir() {
+		if regularManifestExists(skillFile) {
 			targets = append(targets, filepath.ToSlash(filepath.Join("skills", entry.Name())))
 		}
 	}
@@ -1855,6 +1857,8 @@ type ExternalScannerRunner struct {
 	CommandRunner        CommandRunner
 	Env                  map[string]string
 	Profile              string
+	TargetKind           string
+	TargetID             string
 	Registry             ScannerRegistry
 	SandboxMode          string
 	SkillSpectorCommand  []string

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -139,12 +139,10 @@ type Target struct {
 	Kind         string `json:"kind"`
 	Input        string `json:"input"`
 	ResolvedPath string `json:"resolvedPath"`
-}
-
-type resolvedTarget struct {
-	kind         string
-	input        string
-	resolvedPath string
+	// ID is a stable, host-path-free target identity. It is populated for
+	// plugin targets from their manifest and left empty for skills and
+	// URLs, which are already identified by their input.
+	ID string `json:"id,omitempty"`
 }
 
 type ScannerResult struct {
@@ -367,7 +365,16 @@ func Run(opts Options, ctx RunContext) (Artifact, error) {
 		env = EnvMap(os.Environ())
 	}
 	applyRuntimeEnvDefaults(opts, env)
-	if err := ValidateRequirements(opts, env); err != nil {
+	target, err := resolveTarget(opts.Target)
+	if err != nil {
+		return Artifact{}, err
+	}
+	// Requirement validation and sandbox gating only consider scanners that
+	// will run for this target kind; a scanner that can only skip must not
+	// demand credentials or Docker.
+	gatingOpts := opts
+	gatingOpts.Scanners = runnableScanners(opts, target.kind)
+	if err := ValidateRequirements(gatingOpts, env); err != nil {
 		return Artifact{}, err
 	}
 	now := ctx.Now
@@ -375,11 +382,7 @@ func Run(opts Options, ctx RunContext) (Artifact, error) {
 		now = time.Now
 	}
 	startedAt := now().UTC().Format(time.RFC3339Nano)
-	target, err := resolveTarget(opts.Target)
-	if err != nil {
-		return Artifact{}, err
-	}
-	commandRunner, sandbox, err := commandRunnerForOptions(opts, ctx, env)
+	commandRunner, sandbox, err := commandRunnerForOptions(gatingOpts, ctx, env)
 	if err != nil {
 		return Artifact{}, err
 	}
@@ -402,6 +405,7 @@ func Run(opts Options, ctx RunContext) (Artifact, error) {
 	artifact := NewArtifact(opts, target.resolvedPath, startedAt, startedAt, env)
 	artifact.Sandbox = sandbox
 	artifact.Target.Kind = target.kind
+	artifact.Target.ID = target.id
 	if opts.ContextPath != "" {
 		context, err := os.ReadFile(opts.ContextPath)
 		if err != nil {
@@ -415,7 +419,7 @@ func Run(opts Options, ctx RunContext) (Artifact, error) {
 	for _, scanner := range opts.Scanners {
 		scannerStartedAt := now().UTC().Format(time.RFC3339Nano)
 		scannerTimerStarted := time.Now()
-		result, err := scannerResult(opts, scanner, target.resolvedPath, scannerStartedAt, scannerRunner)
+		result, err := scannerResult(opts, scanner, target, scannerStartedAt, scannerRunner)
 		if err != nil {
 			return Artifact{}, err
 		}
@@ -797,7 +801,7 @@ func writeJSONFile(path string, value interface{}) error {
 	return WriteJSON(file, value)
 }
 
-func scannerResult(opts Options, scanner string, target string, startedAt string, scannerRunner ScannerRunner) (ScannerResult, error) {
+func scannerResult(opts Options, scanner string, target resolvedTarget, startedAt string, scannerRunner ScannerRunner) (ScannerResult, error) {
 	if path := opts.ScannerResultPaths[scanner]; path != "" {
 		raw, err := os.ReadFile(path)
 		if err != nil {
@@ -815,29 +819,10 @@ func scannerResult(opts Options, scanner string, target string, startedAt string
 			Raw:         json.RawMessage(raw),
 		}, nil
 	}
-	return scannerRunner.RunScanner(scanner, target, startedAt)
-}
-
-func resolveTarget(input string) (resolvedTarget, error) {
-	if isURLTarget(input) {
-		return resolvedTarget{kind: "url", input: input, resolvedPath: input}, nil
+	if !scannerSupportsTargetKind(scanner, target.kind) {
+		return unsupportedTargetKindResult(scanner, target.kind, startedAt), nil
 	}
-	resolved, err := filepath.Abs(input)
-	if err != nil {
-		return resolvedTarget{}, err
-	}
-	if info, err := os.Lstat(resolved); err != nil || info.Mode()&os.ModeSymlink == 0 {
-		return resolvedTarget{kind: "skill", input: input, resolvedPath: resolved}, nil
-	}
-	if evaluated, err := filepath.EvalSymlinks(resolved); err == nil {
-		resolved = evaluated
-	}
-	return resolvedTarget{kind: "skill", input: input, resolvedPath: resolved}, nil
-}
-
-func isURLTarget(input string) bool {
-	parsed, err := url.Parse(input)
-	return err == nil && parsed.Scheme != "" && parsed.Host != "" && (parsed.Scheme == "http" || parsed.Scheme == "https")
+	return scannerRunner.RunScanner(scanner, target.resolvedPath, startedAt)
 }
 
 var promptPlaceholderPattern = regexp.MustCompile(`\{\{\s*(scanners\.([a-zA-Z0-9_-]+)|target\.files)\s*\}\}`)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -884,6 +884,31 @@ func TestResolveTargetInputsDiscoversSkillChildren(t *testing.T) {
 	}
 }
 
+func TestResolveTargetInputsDoesNotFollowSymlinkedSkillManifest(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "SKILL.md")
+	if err := os.WriteFile(outside, []byte("# Outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "skills", "linked")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(target, "SKILL.md")); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, pluginManifestName), []byte(`{"id":"linked-plugin"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts, err := ParseArgs([]string{"--scanner", "clawscan-static"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if targets, err := ResolveTargetInputs(opts, dir); err == nil || targets != nil || !strings.Contains(err.Error(), "No valid skills found") {
+		t.Fatalf("targets = %#v err = %v", targets, err)
+	}
+}
+
 func TestResolveTargetInputsRejectsMissingSkillsDirectory(t *testing.T) {
 	dir := t.TempDir()
 	opts, err := ParseArgs([]string{"--scanner", "clawscan-static"})

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1474,6 +1474,39 @@ func TestRunUsesSkillSpectorNoLLMWhenProviderKeyMissing(t *testing.T) {
 	}
 }
 
+func TestRunUsesSkillSpectorForPluginDirectory(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, target)
+	commandRunner := &recordingCommandRunner{
+		writeOutput: `{"status":"clean","findings":[]}`,
+	}
+	opts, err := ParseArgs([]string{target, "--scanner", "skillspector", "--sandbox", "off"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := Run(opts, RunContext{
+		Env:                 map[string]string{},
+		CommandRunner:       commandRunner,
+		SkillSpectorCommand: []string{"skillspector"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := artifact.Scanners["skillspector"]; result.Status != "completed" {
+		t.Fatalf("scanner = %#v", result)
+	}
+	if artifact.Target.Kind != targetKindPlugin || artifact.Target.ID != "probe-plugin" {
+		t.Fatalf("target = %#v", artifact.Target)
+	}
+	if len(commandRunner.calls) != 1 {
+		t.Fatalf("calls = %#v", commandRunner.calls)
+	}
+	call := commandRunner.calls[0]
+	if !containsArg(call.args, target) || !containsArg(call.args, "--no-llm") {
+		t.Fatalf("SkillSpector args = %#v", call.args)
+	}
+}
+
 func TestRunSkillSpectorEnablesLLMForProviderEnvVars(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "skill")
@@ -3217,6 +3250,40 @@ func TestNormalizeClawHubSkillSpectorUsesJavaScriptUTF16Truncation(t *testing.T)
 	}
 }
 
+func TestClawHubPromptUsesPackageReleaseContextForPluginTarget(t *testing.T) {
+	artifact := Artifact{
+		Target: Target{Kind: targetKindPlugin, ID: "probe-plugin"},
+		Scanners: map[string]ScannerResult{
+			"virustotal":   {Raw: json.RawMessage(`{"status":"clean","source":"engines","engineStats":{"malicious":0,"suspicious":0,"harmless":3,"undetected":70}}`)},
+			"skillspector": {Raw: json.RawMessage(`{"status":"clean","score":0}`)},
+		},
+	}
+	job := clawHubPromptJob(artifact, clawHubContext{})
+	if job.Job.TargetKind != "packageRelease" {
+		t.Fatalf("target kind = %q", job.Job.TargetKind)
+	}
+	if job.Target.Version != nil || job.Target.Release == nil {
+		t.Fatalf("target evidence slots = %#v", job.Target)
+	}
+	prompt, err := RenderClawHubPrompt("SYSTEM", artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(prompt, "- target kind: packageRelease") {
+		t.Fatalf("plugin prompt missing packageRelease context:\n%s", prompt)
+	}
+}
+
+func TestClawHubPromptPreservesSkillVersionContext(t *testing.T) {
+	job := clawHubPromptJob(Artifact{Target: Target{Kind: targetKindSkill}}, clawHubContext{})
+	if job.Job.TargetKind != "skillVersion" {
+		t.Fatalf("target kind = %q", job.Job.TargetKind)
+	}
+	if job.Target.Version == nil || job.Target.Release != nil {
+		t.Fatalf("target evidence slots = %#v", job.Target)
+	}
+}
+
 func TestRunJudgeWorkspaceIncludesDependencyAndLargeTargetFiles(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -3539,6 +3606,28 @@ func TestPrepareJudgeWorkspacePrioritizesSkillFileWithinBudget(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(workspace, "artifact", "SKILL.md")); err != nil {
 		t.Fatalf("SKILL.md was not copied into judge workspace: %v", err)
+	}
+}
+
+func TestPrepareJudgeWorkspacePrioritizesPluginManifestWithinBudget(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, target)
+	for i := 0; i < 4; i++ {
+		path := filepath.Join(target, fmt.Sprintf("00%d-before-manifest.txt", i))
+		if err := os.WriteFile(path, bytes.Repeat([]byte("x"), maxTargetFileBytes), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	artifact := NewArtifact(Options{Target: target}, target, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", map[string]string{})
+	artifact.Target.Kind = targetKindPlugin
+	artifact.Target.ID = "probe-plugin"
+	if err := prepareJudgeWorkspace(workspace, artifact); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "artifact", pluginManifestName)); err != nil {
+		t.Fatalf("%s was not copied into judge workspace: %v", pluginManifestName, err)
 	}
 }
 

--- a/internal/runner/scanner_registry.go
+++ b/internal/runner/scanner_registry.go
@@ -11,6 +11,10 @@ type ScannerAdapter interface {
 	Requirements(env map[string]string) []EnvRequirement
 	Info() ScannerInfo
 	InstallPlan() InstallPlan
+	// SupportsTargetKind reports whether the adapter can analyze a target of the
+	// given kind. Adapters support skill and URL targets by default; only
+	// plugin-aware adapters accept OpenClaw plugin targets.
+	SupportsTargetKind(kind string) bool
 	Run(runner ExternalScannerRunner, target string, startedAt string) (ScannerResult, error)
 }
 
@@ -108,7 +112,10 @@ type scannerAdapter struct {
 	info          ScannerInfo
 	installPlan   InstallPlan
 	commandBacked bool
-	run           func(runner ExternalScannerRunner, target string, startedAt string) (ScannerResult, error)
+	// supportsPlugins marks adapters that can analyze OpenClaw plugin
+	// targets. Skill and URL kinds are always supported.
+	supportsPlugins bool
+	run             func(runner ExternalScannerRunner, target string, startedAt string) (ScannerResult, error)
 }
 
 func (adapter scannerAdapter) ID() string {
@@ -154,6 +161,13 @@ func (adapter scannerAdapter) InstallPlan() InstallPlan {
 		plan.ScannerID = adapter.id
 	}
 	return plan
+}
+
+func (adapter scannerAdapter) SupportsTargetKind(kind string) bool {
+	if kind == targetKindPlugin {
+		return adapter.supportsPlugins
+	}
+	return true
 }
 
 func (adapter scannerAdapter) Run(runner ExternalScannerRunner, target string, startedAt string) (ScannerResult, error) {
@@ -260,11 +274,12 @@ func defaultScannerAdapters() []ScannerAdapter {
 			run: ExternalScannerRunner.runCisco,
 		},
 		scannerAdapter{
-			id: "clawscan-static",
+			id:              "clawscan-static",
+			supportsPlugins: true,
 			info: ScannerInfo{
 				DisplayName:   "ClawScan Static",
 				RepositoryURL: "https://github.com/openclaw/clawscan",
-				Description:   "Built-in deterministic text scanner for high-signal risky skill patterns.",
+				Description:   "Built-in deterministic text scanner for high-signal risky skill and plugin patterns.",
 			},
 			installPlan: InstallPlan{
 				ScannerID:       "clawscan-static",

--- a/internal/runner/scanner_registry.go
+++ b/internal/runner/scanner_registry.go
@@ -339,9 +339,10 @@ func defaultScannerAdapters() []ScannerAdapter {
 			run: ExternalScannerRunner.runSnyk,
 		},
 		scannerAdapter{
-			id:            "socket",
-			requirements:  staticEnvRequirements("scanner socket", "SOCKET_CLI_API_TOKEN"),
-			commandBacked: true,
+			id:              "socket",
+			requirements:    staticEnvRequirements("scanner socket", "SOCKET_CLI_API_TOKEN"),
+			commandBacked:   true,
+			supportsPlugins: true,
 			info: ScannerInfo{
 				DisplayName:   "Socket CLI",
 				RepositoryURL: "https://github.com/SocketDev/socket-cli",

--- a/internal/runner/scanner_registry.go
+++ b/internal/runner/scanner_registry.go
@@ -289,12 +289,13 @@ func defaultScannerAdapters() []ScannerAdapter {
 			run: ExternalScannerRunner.runStatic,
 		},
 		scannerAdapter{
-			id:            "skillspector",
-			commandBacked: true,
+			id:              "skillspector",
+			commandBacked:   true,
+			supportsPlugins: true,
 			info: ScannerInfo{
 				DisplayName:   "NVIDIA SkillSpector",
 				RepositoryURL: "https://github.com/NVIDIA/skillspector",
-				Description:   "Local file or directory scanner. Uses SkillSpector LLM mode when provider env vars are set; otherwise runs with --no-llm.",
+				Description:   "Local skill or OpenClaw plugin file/directory scanner. Uses SkillSpector LLM mode when provider env vars are set; otherwise runs with --no-llm.",
 				OptionalEnv: []string{
 					"SKILLSPECTOR_PROVIDER",
 					"SKILLSPECTOR_MODEL",
@@ -358,12 +359,13 @@ func defaultScannerAdapters() []ScannerAdapter {
 			run: ExternalScannerRunner.runSocket,
 		},
 		scannerAdapter{
-			id:           "virustotal",
-			requirements: staticEnvRequirements("scanner virustotal", "VIRUSTOTAL_API_KEY"),
+			id:              "virustotal",
+			requirements:    staticEnvRequirements("scanner virustotal", "VIRUSTOTAL_API_KEY"),
+			supportsPlugins: true,
 			info: ScannerInfo{
 				DisplayName:   "VirusTotal API",
 				RepositoryURL: "https://docs.virustotal.com/reference/file",
-				Description:   "API-backed single local file hash lookup. Directories return a skipped result.",
+				Description:   "API-backed local file hash lookup. Skill and OpenClaw plugin directories are scanned as deterministic ZIP archives.",
 			},
 			installPlan: InstallPlan{
 				ScannerID:       "virustotal",

--- a/internal/runner/scanner_registry_test.go
+++ b/internal/runner/scanner_registry_test.go
@@ -102,7 +102,7 @@ func TestScannerAdaptersDeclareTargetKindSupport(t *testing.T) {
 		if !adapter.SupportsTargetKind(targetKindURL) {
 			t.Fatalf("%s should support url targets", id)
 		}
-		wantPlugin := id == "clawscan-static" || id == "skillspector" || id == "virustotal"
+		wantPlugin := id == "clawscan-static" || id == "skillspector" || id == "socket" || id == "virustotal"
 		if got := adapter.SupportsTargetKind(targetKindPlugin); got != wantPlugin {
 			t.Fatalf("%s plugin support = %v, want %v", id, got, wantPlugin)
 		}
@@ -115,6 +115,9 @@ func TestScannerAdaptersDeclareTargetKindSupport(t *testing.T) {
 	}
 	if !scannerSupportsTargetKind("virustotal", targetKindPlugin) {
 		t.Fatal("virustotal should support plugin targets")
+	}
+	if !scannerSupportsTargetKind("socket", targetKindPlugin) {
+		t.Fatal("socket should support plugin targets")
 	}
 	if !scannerSupportsTargetKind("unknown-scanner", targetKindPlugin) {
 		t.Fatal("unknown scanners should be permitted so the runner emits its own skipped result")

--- a/internal/runner/scanner_registry_test.go
+++ b/internal/runner/scanner_registry_test.go
@@ -102,7 +102,7 @@ func TestScannerAdaptersDeclareTargetKindSupport(t *testing.T) {
 		if !adapter.SupportsTargetKind(targetKindURL) {
 			t.Fatalf("%s should support url targets", id)
 		}
-		wantPlugin := id == "clawscan-static"
+		wantPlugin := id == "clawscan-static" || id == "skillspector" || id == "virustotal"
 		if got := adapter.SupportsTargetKind(targetKindPlugin); got != wantPlugin {
 			t.Fatalf("%s plugin support = %v, want %v", id, got, wantPlugin)
 		}
@@ -110,8 +110,11 @@ func TestScannerAdaptersDeclareTargetKindSupport(t *testing.T) {
 	if !scannerSupportsTargetKind("clawscan-static", targetKindPlugin) {
 		t.Fatal("clawscan-static should support plugin targets")
 	}
-	if scannerSupportsTargetKind("skillspector", targetKindPlugin) {
-		t.Fatal("skillspector should not support plugin targets")
+	if !scannerSupportsTargetKind("skillspector", targetKindPlugin) {
+		t.Fatal("skillspector should support plugin targets")
+	}
+	if !scannerSupportsTargetKind("virustotal", targetKindPlugin) {
+		t.Fatal("virustotal should support plugin targets")
 	}
 	if !scannerSupportsTargetKind("unknown-scanner", targetKindPlugin) {
 		t.Fatal("unknown scanners should be permitted so the runner emits its own skipped result")

--- a/internal/runner/scanner_registry_test.go
+++ b/internal/runner/scanner_registry_test.go
@@ -8,11 +8,12 @@ import (
 )
 
 type stubScannerAdapter struct {
-	id           string
-	requirements []EnvRequirement
-	info         ScannerInfo
-	installPlan  InstallPlan
-	run          func(target string, startedAt string) (ScannerResult, error)
+	id              string
+	requirements    []EnvRequirement
+	info            ScannerInfo
+	installPlan     InstallPlan
+	supportsPlugins bool
+	run             func(target string, startedAt string) (ScannerResult, error)
 }
 
 func (adapter stubScannerAdapter) ID() string {
@@ -29,6 +30,13 @@ func (adapter stubScannerAdapter) Info() ScannerInfo {
 
 func (adapter stubScannerAdapter) InstallPlan() InstallPlan {
 	return adapter.installPlan
+}
+
+func (adapter stubScannerAdapter) SupportsTargetKind(kind string) bool {
+	if kind == targetKindPlugin {
+		return adapter.supportsPlugins
+	}
+	return true
 }
 
 func (adapter stubScannerAdapter) Run(_ ExternalScannerRunner, target string, startedAt string) (ScannerResult, error) {
@@ -78,6 +86,35 @@ func TestDefaultScannerRegistryContainsAllBuiltIns(t *testing.T) {
 	want := "agentverus,aig,cisco,clawscan-static,skillspector,snyk,socket,virustotal"
 	if got := strings.Join(DefaultScannerRegistry().IDs(), ","); got != want {
 		t.Fatalf("ids = %q, want %q", got, want)
+	}
+}
+
+func TestScannerAdaptersDeclareTargetKindSupport(t *testing.T) {
+	registry := DefaultScannerRegistry()
+	for _, id := range registry.IDs() {
+		adapter, ok := registry.Adapter(id)
+		if !ok {
+			t.Fatalf("missing adapter for %s", id)
+		}
+		if !adapter.SupportsTargetKind(targetKindSkill) {
+			t.Fatalf("%s should support skill targets", id)
+		}
+		if !adapter.SupportsTargetKind(targetKindURL) {
+			t.Fatalf("%s should support url targets", id)
+		}
+		wantPlugin := id == "clawscan-static"
+		if got := adapter.SupportsTargetKind(targetKindPlugin); got != wantPlugin {
+			t.Fatalf("%s plugin support = %v, want %v", id, got, wantPlugin)
+		}
+	}
+	if !scannerSupportsTargetKind("clawscan-static", targetKindPlugin) {
+		t.Fatal("clawscan-static should support plugin targets")
+	}
+	if scannerSupportsTargetKind("skillspector", targetKindPlugin) {
+		t.Fatal("skillspector should not support plugin targets")
+	}
+	if !scannerSupportsTargetKind("unknown-scanner", targetKindPlugin) {
+		t.Fatal("unknown scanners should be permitted so the runner emits its own skipped result")
 	}
 }
 

--- a/internal/runner/static_scanner.go
+++ b/internal/runner/static_scanner.go
@@ -272,7 +272,8 @@ func (files *staticScannerFiles) recordWalkError(root string, path string, entry
 }
 
 func staticFilePriority(path string) int {
-	if strings.EqualFold(filepath.ToSlash(path), "SKILL.md") {
+	normalized := filepath.ToSlash(path)
+	if strings.EqualFold(normalized, "SKILL.md") || strings.EqualFold(normalized, "openclaw.plugin.json") {
 		return 0
 	}
 	return 1

--- a/internal/runner/target.go
+++ b/internal/runner/target.go
@@ -1,0 +1,258 @@
+package runner
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// skillManifestName and pluginManifestName are the manifest files that mark an
+// OpenClaw skill and an OpenClaw plugin. Classification treats them as
+// the single source of truth for target identity.
+const (
+	skillManifestName  = "SKILL.md"
+	pluginManifestName = "openclaw.plugin.json"
+)
+
+// validPluginID ports OpenClaw's validatePluginId install-path rules: a bare
+// name or an @scope/name pair, with no backslashes, empty segments, or
+// reserved path segments, so the identity recorded in artifacts can never
+// smuggle a host path and any id the host runtime accepts is accepted here.
+// The only addition is rejecting control characters, which keeps recorded
+// identities safe for artifacts and terminal output.
+func validPluginID(id string) bool {
+	if id == "" || strings.Contains(id, `\`) {
+		return false
+	}
+	for _, r := range id {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+	}
+	segments := strings.Split(id, "/")
+	for _, segment := range segments {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+	}
+	switch len(segments) {
+	case 1:
+		return !strings.HasPrefix(id, "@")
+	case 2:
+		return strings.HasPrefix(segments[0], "@") && len(segments[0]) >= 2
+	default:
+		return false
+	}
+}
+
+// Target kinds recorded in run artifacts and used for scanner compatibility.
+// skill and url preserve the historical Clawscan behavior; plugin is the
+// first-class OpenClaw plugin target added alongside them.
+const (
+	targetKindSkill  = "skill"
+	targetKindPlugin = "plugin"
+	targetKindURL    = "url"
+)
+
+// maxPluginManifestBytes matches OpenClaw's MAX_PLUGIN_MANIFEST_BYTES so a
+// manifest the host runtime accepts is never rejected here for size.
+const maxPluginManifestBytes = 256 * 1024
+
+// resolvedTarget is the small target abstraction the runner threads from the
+// scan input through scanner dispatch and into the artifact. It carries enough
+// to run scanners (resolvedPath), decide scanner compatibility (kind), and
+// report a stable identity (id) without leaking that identity from a host path.
+type resolvedTarget struct {
+	kind         string
+	input        string
+	resolvedPath string
+	// id is a stable, host-path-free identity. It is populated for plugin
+	// targets from their manifest and empty for skills and URLs.
+	id string
+}
+
+func resolveTarget(input string) (resolvedTarget, error) {
+	if isURLTarget(input) {
+		return resolvedTarget{kind: targetKindURL, input: input, resolvedPath: input}, nil
+	}
+	resolved, err := filepath.Abs(input)
+	if err != nil {
+		return resolvedTarget{}, err
+	}
+	// The top-level target path is operator input, so a symlink here is
+	// resolved deliberately, matching how a shell would treat it. Manifests
+	// found inside the target are untrusted content and never followed; see
+	// regularManifestExists and readPluginID.
+	if info, err := os.Lstat(resolved); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		if evaluated, evalErr := filepath.EvalSymlinks(resolved); evalErr == nil {
+			resolved = evaluated
+		}
+	}
+	kind, id, err := classifyLocalTarget(resolved, input)
+	if err != nil {
+		return resolvedTarget{}, err
+	}
+	// A plugin classified via its manifest file is scanned as its directory so
+	// scanners see the plugin code, not just the manifest.
+	if kind == targetKindPlugin {
+		if info, err := os.Stat(resolved); err == nil && !info.IsDir() {
+			resolved = filepath.Dir(resolved)
+		}
+	}
+	return resolvedTarget{kind: kind, input: input, resolvedPath: resolved, id: id}, nil
+}
+
+// classifyLocalTarget decides whether a resolved local path is a skill or an
+// OpenClaw plugin. It defaults to skill so existing skill scans, single-file
+// targets, and missing paths behave exactly as before; only an explicit plugin
+// manifest promotes the target to a plugin. A directory carrying both manifests
+// is rejected as ambiguous rather than silently guessed.
+func classifyLocalTarget(resolvedPath string, input string) (kind string, id string, err error) {
+	info, statErr := os.Stat(resolvedPath)
+	if statErr != nil {
+		return targetKindSkill, "", nil
+	}
+	dir := resolvedPath
+	if !info.IsDir() {
+		switch filepath.Base(resolvedPath) {
+		case pluginManifestName:
+			dir = filepath.Dir(resolvedPath)
+		default:
+			// SKILL.md or any other single file keeps the historical skill kind.
+			return targetKindSkill, "", nil
+		}
+	}
+	hasPlugin := regularManifestExists(filepath.Join(dir, pluginManifestName))
+	hasSkill := regularManifestExists(filepath.Join(dir, skillManifestName))
+	if !hasPlugin {
+		return targetKindSkill, "", nil
+	}
+	if hasSkill {
+		return "", "", fmt.Errorf("target %s contains both %s and %s; point Clawscan at a directory with exactly one manifest", displayTargetInput(input), skillManifestName, pluginManifestName)
+	}
+	id, err = readPluginID(filepath.Join(dir, pluginManifestName))
+	if err != nil {
+		return "", "", fmt.Errorf("target %s is not a valid plugin: %w", displayTargetInput(input), err)
+	}
+	return targetKindPlugin, id, nil
+}
+
+// regularManifestExists reports whether path is an existing regular file
+// without following symlinks. A target cannot present a symlinked or special
+// manifest to be classified: an untrusted target could point its manifest at a
+// host file outside the target, so only a real regular file counts here.
+func regularManifestExists(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// readPluginID parses the stable plugin identity from a plugin manifest and
+// validates it against the canonical OpenClaw plugin identifier grammar, so the
+// identity recorded in artifacts is always well-formed.
+//
+// It never follows a symlink: the manifest is opened O_NOFOLLOW and re-checked
+// against a leading lstat, so a target that swaps its regular manifest for an
+// symlink (racing between classification and read) fails closed instead of
+// exposing an outside host file. The lstat/fstat identity check backstops
+// platforms without an O_NOFOLLOW equivalent.
+func readPluginID(manifestPath string) (string, error) {
+	before, err := os.Lstat(manifestPath)
+	if err != nil {
+		return "", err
+	}
+	if !before.Mode().IsRegular() {
+		return "", fmt.Errorf("%s must be a regular file, not a symlink or special file", pluginManifestName)
+	}
+	file, err := os.OpenFile(manifestPath, os.O_RDONLY|openNoFollowFlag, 0)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil {
+		return "", err
+	}
+	if !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+		return "", fmt.Errorf("%s changed while it was being read", pluginManifestName)
+	}
+	if opened.Size() > maxPluginManifestBytes {
+		return "", fmt.Errorf("%s exceeds the %d KiB manifest limit", pluginManifestName, maxPluginManifestBytes/1024)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxPluginManifestBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if int64(len(data)) > maxPluginManifestBytes {
+		return "", fmt.Errorf("%s exceeds the %d KiB manifest limit", pluginManifestName, maxPluginManifestBytes/1024)
+	}
+	var manifest struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return "", fmt.Errorf("parse %s (strict JSON; JSON5-only manifests are not supported yet): %w", pluginManifestName, err)
+	}
+	id := strings.TrimSpace(manifest.ID)
+	if !validPluginID(id) {
+		return "", fmt.Errorf("%s has an invalid plugin id %q", pluginManifestName, id)
+	}
+	return id, nil
+}
+
+// displayTargetInput echoes the operator-provided target back in errors. It is
+// the input the caller typed, not a resolved host path, so classification
+// failures stay legible without widening host-path exposure.
+func displayTargetInput(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "the scan target"
+	}
+	return input
+}
+
+func isURLTarget(input string) bool {
+	parsed, err := url.Parse(input)
+	return err == nil && parsed.Scheme != "" && parsed.Host != "" && (parsed.Scheme == "http" || parsed.Scheme == "https")
+}
+
+// runnableScanners filters the selected scanners down to those that will
+// actually execute against this target kind, so requirement validation and
+// sandbox gating never demand credentials or Docker for scanners that can only
+// produce a skipped result. Pre-supplied scanner results are kept; they never
+// execute anything.
+func runnableScanners(opts Options, kind string) []string {
+	var out []string
+	for _, scanner := range opts.Scanners {
+		if opts.ScannerResultPaths[scanner] == "" && !scannerSupportsTargetKind(scanner, kind) {
+			continue
+		}
+		out = append(out, scanner)
+	}
+	return out
+}
+
+// scannerSupportsTargetKind reports whether a built-in scanner can run against a
+// target of the given kind. Unknown scanner IDs are permitted here so the
+// scanner runner can still emit its own skipped result for them.
+func scannerSupportsTargetKind(scanner string, kind string) bool {
+	adapter, ok := DefaultScannerRegistry().Adapter(scanner)
+	if !ok {
+		return true
+	}
+	return adapter.SupportsTargetKind(kind)
+}
+
+// unsupportedTargetKindResult is the explicit skipped result a skill-only
+// scanner returns for a target kind it cannot analyze.
+func unsupportedTargetKindResult(scanner string, kind string, startedAt string) ScannerResult {
+	return ScannerResult{
+		Status:      "skipped",
+		StartedAt:   startedAt,
+		CompletedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		Error:       fmt.Sprintf("Scanner %s does not support %s targets.", scanner, kind),
+	}
+}

--- a/internal/runner/target.go
+++ b/internal/runner/target.go
@@ -111,17 +111,20 @@ func resolveTarget(input string) (resolvedTarget, error) {
 // OpenClaw plugin. It defaults to skill so existing skill scans, single-file
 // targets, and missing paths behave exactly as before; only an explicit plugin
 // manifest promotes the target to a plugin. A directory carrying both manifests
-// is rejected as ambiguous rather than silently guessed.
+// is rejected as ambiguous, but an explicitly selected manifest disambiguates
+// the package without guessing.
 func classifyLocalTarget(resolvedPath string, input string) (kind string, id string, err error) {
 	info, statErr := os.Stat(resolvedPath)
 	if statErr != nil {
 		return targetKindSkill, "", nil
 	}
 	dir := resolvedPath
+	explicitPluginManifest := false
 	if !info.IsDir() {
 		switch filepath.Base(resolvedPath) {
 		case pluginManifestName:
 			dir = filepath.Dir(resolvedPath)
+			explicitPluginManifest = true
 		default:
 			// SKILL.md or any other single file keeps the historical skill kind.
 			return targetKindSkill, "", nil
@@ -132,8 +135,8 @@ func classifyLocalTarget(resolvedPath string, input string) (kind string, id str
 	if !hasPlugin {
 		return targetKindSkill, "", nil
 	}
-	if hasSkill {
-		return "", "", fmt.Errorf("target %s contains both %s and %s; point Clawscan at a directory with exactly one manifest", displayTargetInput(input), skillManifestName, pluginManifestName)
+	if hasSkill && !explicitPluginManifest {
+		return "", "", fmt.Errorf("target %s contains both %s and %s; point Clawscan directly at the desired manifest", displayTargetInput(input), skillManifestName, pluginManifestName)
 	}
 	id, err = readPluginID(filepath.Join(dir, pluginManifestName))
 	if err != nil {

--- a/internal/runner/target.go
+++ b/internal/runner/target.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/alchemy/json5"
 )
 
 // skillManifestName and pluginManifestName are the manifest files that mark an
@@ -98,8 +100,12 @@ func resolveTarget(input string) (resolvedTarget, error) {
 		return resolvedTarget{}, err
 	}
 	// A plugin classified via its manifest file is scanned as its directory so
-	// scanners see the plugin code, not just the manifest.
-	if kind == targetKindPlugin {
+	// scanners see the plugin code, not just the manifest. In a dual-layout
+	// package, an explicit SKILL.md similarly disambiguates the target without
+	// narrowing the scan to that one file.
+	if kind == targetKindPlugin ||
+		(kind == targetKindSkill && sameManifestFile(resolved, skillManifestName) &&
+			regularManifestExists(filepath.Join(filepath.Dir(resolved), pluginManifestName))) {
 		if info, err := os.Stat(resolved); err == nil && !info.IsDir() {
 			resolved = filepath.Dir(resolved)
 		}
@@ -121,11 +127,10 @@ func classifyLocalTarget(resolvedPath string, input string) (kind string, id str
 	dir := resolvedPath
 	explicitPluginManifest := false
 	if !info.IsDir() {
-		switch filepath.Base(resolvedPath) {
-		case pluginManifestName:
+		if sameManifestFile(resolvedPath, pluginManifestName) {
 			dir = filepath.Dir(resolvedPath)
 			explicitPluginManifest = true
-		default:
+		} else {
 			// SKILL.md or any other single file keeps the historical skill kind.
 			return targetKindSkill, "", nil
 		}
@@ -152,6 +157,19 @@ func classifyLocalTarget(resolvedPath string, input string) (kind string, id str
 func regularManifestExists(path string) bool {
 	info, err := os.Lstat(path)
 	return err == nil && info.Mode().IsRegular()
+}
+
+// sameManifestFile recognizes an explicitly selected manifest by filesystem
+// identity, not spelling. This preserves manifest targeting on case-insensitive
+// filesystems while still requiring the canonical in-directory manifest to be
+// a real regular file.
+func sameManifestFile(path string, manifestName string) bool {
+	selected, err := os.Stat(path)
+	if err != nil || selected.IsDir() {
+		return false
+	}
+	canonical, err := os.Lstat(filepath.Join(filepath.Dir(path), manifestName))
+	return err == nil && canonical.Mode().IsRegular() && os.SameFile(selected, canonical)
 }
 
 // readPluginID parses the stable plugin identity from a plugin manifest and
@@ -193,13 +211,18 @@ func readPluginID(manifestPath string) (string, error) {
 	if int64(len(data)) > maxPluginManifestBytes {
 		return "", fmt.Errorf("%s exceeds the %d KiB manifest limit", pluginManifestName, maxPluginManifestBytes/1024)
 	}
-	var manifest struct {
-		ID string `json:"id"`
-	}
+	var manifest map[string]any
 	if err := json.Unmarshal(data, &manifest); err != nil {
-		return "", fmt.Errorf("parse %s (strict JSON; JSON5-only manifests are not supported yet): %w", pluginManifestName, err)
+		manifest = nil
+		if err := json5.Unmarshal(data, &manifest); err != nil {
+			return "", fmt.Errorf("parse %s: %w", pluginManifestName, err)
+		}
 	}
-	id := strings.TrimSpace(manifest.ID)
+	id, ok := manifest["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("%s has an invalid plugin id", pluginManifestName)
+	}
+	id = strings.TrimSpace(id)
 	if !validPluginID(id) {
 		return "", fmt.Errorf("%s has an invalid plugin id %q", pluginManifestName, id)
 	}

--- a/internal/runner/target_nofollow_unix.go
+++ b/internal/runner/target_nofollow_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package runner
+
+import "syscall"
+
+// openNoFollowFlag refuses to open the final path component if it is a symlink,
+// closing the window where an untrusted target swaps a regular manifest for a
+// symlink between classification and read.
+const openNoFollowFlag = syscall.O_NOFOLLOW

--- a/internal/runner/target_nofollow_windows.go
+++ b/internal/runner/target_nofollow_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package runner
+
+// Windows has no portable O_NOFOLLOW open flag, so the open itself may follow
+// a reparse point. The leading lstat regular-file guard rejects a symlinked
+// manifest before any open, and the post-open same-file identity check in
+// readPluginID fails closed if the manifest is swapped for a symlink between
+// those steps; the open-time traversal window itself is not eliminated on
+// Windows.
+const openNoFollowFlag = 0

--- a/internal/runner/target_test.go
+++ b/internal/runner/target_test.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -259,29 +261,70 @@ func TestResolveTargetRejectsInvalidPluginID(t *testing.T) {
 	}
 }
 
-func TestRunSkipsSkillOnlyScannerForPluginTarget(t *testing.T) {
+func TestRunDispatchesClawHubScannersForPluginTarget(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "probe-plugin")
 	writeProbePlugin(t, dir)
-	opts, err := ParseArgs([]string{dir, "--scanner", "skillspector"})
+	opts, err := ParseArgs([]string{
+		dir,
+		"--scanner", "skillspector",
+		"--scanner", "virustotal",
+		"--scanner", "clawscan-static",
+		"--sandbox", "off",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	artifact, err := Run(opts, RunContext{Env: map[string]string{}})
+	scannerRunner := &recordingPluginScannerRunner{}
+	artifact, err := Run(opts, RunContext{
+		Env:           map[string]string{"VIRUSTOTAL_API_KEY": "present"},
+		ScannerRunner: scannerRunner,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if artifact.Target.Kind != targetKindPlugin || artifact.Target.ID != "probe-plugin" {
 		t.Fatalf("target = %#v", artifact.Target)
 	}
-	result := artifact.Scanners["skillspector"]
-	if result.Status != "skipped" {
-		t.Fatalf("status = %q error = %q", result.Status, result.Error)
+	wantScanners := "skillspector,virustotal,clawscan-static"
+	if got := strings.Join(scannerRunner.scanners, ","); got != wantScanners {
+		t.Fatalf("dispatched scanners = %q, want %q", got, wantScanners)
 	}
-	if !strings.Contains(result.Error, "does not support plugin targets") {
-		t.Fatalf("error = %q", result.Error)
+	for _, scanner := range opts.Scanners {
+		result := artifact.Scanners[scanner]
+		if result.Status != "completed" {
+			t.Fatalf("%s result = %#v", scanner, result)
+		}
 	}
-	if len(result.Raw) != 0 {
-		t.Fatalf("raw = %s", result.Raw)
+}
+
+func TestRunPluginTargetRequiresVirusTotalCredential(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, dir)
+	opts, err := ParseArgs([]string{dir, "--scanner", "virustotal"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Run(opts, RunContext{Env: map[string]string{}})
+	if err == nil || !strings.Contains(err.Error(), "VIRUSTOTAL_API_KEY required by scanner virustotal") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestRunPluginTargetRequiresDockerForSkillSpectorByDefault(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, dir)
+	opts, err := ParseArgs([]string{dir, "--scanner", "skillspector"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Run(opts, RunContext{
+		Env: map[string]string{},
+		DockerAvailability: func() error {
+			return errors.New("sandbox-probe")
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "Docker sandbox is required") || !strings.Contains(err.Error(), "sandbox-probe") {
+		t.Fatalf("err = %v", err)
 	}
 }
 
@@ -323,4 +366,21 @@ func TestRunFailsForInvalidPluginManifest(t *testing.T) {
 	if _, err := Run(opts, RunContext{Env: map[string]string{}}); err == nil || !strings.Contains(err.Error(), "not a valid plugin") {
 		t.Fatalf("err = %v", err)
 	}
+}
+
+type recordingPluginScannerRunner struct {
+	scanners []string
+}
+
+func (runner *recordingPluginScannerRunner) RunScanner(name string, target string, startedAt string) (ScannerResult, error) {
+	runner.scanners = append(runner.scanners, name)
+	if _, err := os.Stat(filepath.Join(target, pluginManifestName)); err != nil {
+		return ScannerResult{}, err
+	}
+	return ScannerResult{
+		Status:      "completed",
+		StartedAt:   startedAt,
+		CompletedAt: startedAt,
+		Raw:         json.RawMessage(`{"ok":true}`),
+	}, nil
 }

--- a/internal/runner/target_test.go
+++ b/internal/runner/target_test.go
@@ -1,0 +1,326 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const probePluginManifest = `{
+  "id": "probe-plugin",
+  "name": "Probe Plugin",
+  "contracts": { "tools": ["probe_tool"] }
+}`
+
+func writeProbePlugin(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "openclaw.plugin.json"), []byte(probePluginManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.js"), []byte("// synthetic probe\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveTargetClassifiesPluginDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, dir)
+	resolved, err := resolveTarget(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.kind != targetKindPlugin {
+		t.Fatalf("kind = %q", resolved.kind)
+	}
+	if resolved.id != "probe-plugin" {
+		t.Fatalf("id = %q", resolved.id)
+	}
+	expected, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		expected = dir
+	}
+	if resolved.resolvedPath != expected {
+		t.Fatalf("resolvedPath = %q, want %q", resolved.resolvedPath, expected)
+	}
+}
+
+func TestResolveTargetClassifiesPluginManifestFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, dir)
+	resolved, err := resolveTarget(filepath.Join(dir, "openclaw.plugin.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.kind != targetKindPlugin || resolved.id != "probe-plugin" {
+		t.Fatalf("resolved = %#v", resolved)
+	}
+	expected, evalErr := filepath.EvalSymlinks(dir)
+	if evalErr != nil {
+		expected = dir
+	}
+	if resolved.resolvedPath != expected {
+		t.Fatalf("manifest-file target must scan the plugin directory: resolvedPath = %q, want %q", resolved.resolvedPath, expected)
+	}
+}
+
+func TestValidPluginIDAcceptsHostGrammar(t *testing.T) {
+	valid := []string{"probe-plugin", "memory-lancedb-pro", "@scope/name", "@a/b", "Probe.Plugin_2", "has space", "caf\u00e9-plugin", strings.Repeat("a", 300)}
+	for _, id := range valid {
+		if !validPluginID(id) {
+			t.Fatalf("validPluginID(%q) = false, want true", id)
+		}
+	}
+	invalid := []string{"", "@scope", "@/name", "a/b/c", "../escape", "@scope/..", `a\b`, "@scope/", "bad\x01id", "bad\nid"}
+	for _, id := range invalid {
+		if validPluginID(id) {
+			t.Fatalf("validPluginID(%q) = true, want false", id)
+		}
+	}
+}
+
+func TestResolveTargetAcceptsScopedPluginID(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "scoped-plugin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "openclaw.plugin.json"), []byte(`{"id":"@scope/probe-plugin"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := resolveTarget(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.kind != targetKindPlugin || resolved.id != "@scope/probe-plugin" {
+		t.Fatalf("resolved = %#v", resolved)
+	}
+}
+
+func TestRunPluginTargetDoesNotDemandSkillOnlyScannerCredentials(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, dir)
+	opts, err := ParseArgs([]string{dir, "--scanner", "snyk"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// snyk is skill-only, so a plugin scan must yield its skipped result even
+	// though SNYK_TOKEN is absent from the environment.
+	artifact, err := Run(opts, RunContext{Env: map[string]string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := artifact.Scanners["snyk"]
+	if result.Status != "skipped" || !strings.Contains(result.Error, "does not support plugin targets") {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestResolveTargetKeepsSkillClassification(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "skill")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# Demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := resolveTarget(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.kind != targetKindSkill || resolved.id != "" {
+		t.Fatalf("resolved = %#v", resolved)
+	}
+}
+
+func TestResolveTargetDefaultsPlainInputsToSkill(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(file, []byte("# readme\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, input := range []string{file, dir, filepath.Join(dir, "missing")} {
+		resolved, err := resolveTarget(input)
+		if err != nil {
+			t.Fatalf("resolveTarget(%q) error = %v", input, err)
+		}
+		if resolved.kind != targetKindSkill || resolved.id != "" {
+			t.Fatalf("resolveTarget(%q) = %#v", input, resolved)
+		}
+	}
+}
+
+func TestResolveTargetRejectsAmbiguousManifests(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "ambiguous")
+	writeProbePlugin(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# Demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := resolveTarget(dir)
+	if err == nil || !strings.Contains(err.Error(), "exactly one manifest") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestResolveTargetIgnoresSymlinkedPluginManifest(t *testing.T) {
+	// A hostile target must not be able to point openclaw.plugin.json at a host
+	// file outside the target and be classified/read as that plugin.
+	outsideDir := t.TempDir()
+	outside := filepath.Join(outsideDir, "openclaw.plugin.json")
+	if err := os.WriteFile(outside, []byte(`{"id":"outside-evil"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "probe-plugin")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(target, "openclaw.plugin.json")); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+	resolved, err := resolveTarget(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.kind != targetKindSkill || resolved.id != "" {
+		t.Fatalf("symlinked manifest was followed: %#v", resolved)
+	}
+}
+
+func TestReadPluginIDRejectsSymlinkManifest(t *testing.T) {
+	outsideDir := t.TempDir()
+	outside := filepath.Join(outsideDir, "secret.json")
+	if err := os.WriteFile(outside, []byte(`{"id":"outside-evil"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "openclaw.plugin.json")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+	id, err := readPluginID(link)
+	if err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("id = %q err = %v", id, err)
+	}
+	if id != "" {
+		t.Fatalf("id leaked from symlinked manifest: %q", id)
+	}
+}
+
+func TestReadPluginIDReadsRegularManifest(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, dir)
+	id, err := readPluginID(filepath.Join(dir, "openclaw.plugin.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "probe-plugin" {
+		t.Fatalf("id = %q", id)
+	}
+}
+
+func TestResolveTargetIgnoresSymlinkManifestNextToSkill(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "mixed")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# Demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "openclaw.plugin.json")
+	if err := os.WriteFile(outside, []byte(`{"id":"outside-evil"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "openclaw.plugin.json")); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+	// The symlinked plugin manifest is not a real manifest, so the directory is
+	// an unambiguous skill rather than a rejected ambiguous target.
+	resolved, err := resolveTarget(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.kind != targetKindSkill || resolved.id != "" {
+		t.Fatalf("resolved = %#v", resolved)
+	}
+}
+
+func TestResolveTargetRejectsInvalidPluginID(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "bad-plugin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "openclaw.plugin.json"), []byte(`{"id":"../escape"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := resolveTarget(dir)
+	if err == nil || !strings.Contains(err.Error(), "invalid plugin id") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestRunSkipsSkillOnlyScannerForPluginTarget(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, dir)
+	opts, err := ParseArgs([]string{dir, "--scanner", "skillspector"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := Run(opts, RunContext{Env: map[string]string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Target.Kind != targetKindPlugin || artifact.Target.ID != "probe-plugin" {
+		t.Fatalf("target = %#v", artifact.Target)
+	}
+	result := artifact.Scanners["skillspector"]
+	if result.Status != "skipped" {
+		t.Fatalf("status = %q error = %q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, "does not support plugin targets") {
+		t.Fatalf("error = %q", result.Error)
+	}
+	if len(result.Raw) != 0 {
+		t.Fatalf("raw = %s", result.Raw)
+	}
+}
+
+func TestRunStaticScannerCompletesForPluginTarget(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, dir)
+	opts, err := ParseArgs([]string{dir, "--scanner", "clawscan-static"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := Run(opts, RunContext{Env: map[string]string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Target.Kind != targetKindPlugin || artifact.Target.ID != "probe-plugin" {
+		t.Fatalf("target = %#v", artifact.Target)
+	}
+	result := artifact.Scanners["clawscan-static"]
+	if result.Status != "completed" || len(result.Raw) == 0 {
+		t.Fatalf("result = %#v", result)
+	}
+	if !strings.Contains(string(result.Raw), "index.js") {
+		t.Fatalf("static scan must cover plugin code, not just the manifest: %s", result.Raw)
+	}
+}
+
+func TestRunFailsForInvalidPluginManifest(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "bad-plugin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "openclaw.plugin.json"), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts, err := ParseArgs([]string{dir, "--scanner", "clawscan-static"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Run(opts, RunContext{Env: map[string]string{}}); err == nil || !strings.Contains(err.Error(), "not a valid plugin") {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/internal/runner/target_test.go
+++ b/internal/runner/target_test.go
@@ -161,8 +161,23 @@ func TestResolveTargetRejectsAmbiguousManifests(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err := resolveTarget(dir)
-	if err == nil || !strings.Contains(err.Error(), "exactly one manifest") {
+	if err == nil || !strings.Contains(err.Error(), "desired manifest") {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestResolveTargetExplicitPluginManifestDisambiguatesDualLayout(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "dual-layout")
+	writeProbePlugin(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, skillManifestName), []byte("# Bundled skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := resolveTarget(filepath.Join(dir, pluginManifestName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.kind != targetKindPlugin || resolved.id != "probe-plugin" || resolved.resolvedPath != dir {
+		t.Fatalf("resolved = %#v", resolved)
 	}
 }
 

--- a/internal/runner/target_test.go
+++ b/internal/runner/target_test.go
@@ -69,6 +69,22 @@ func TestResolveTargetClassifiesPluginManifestFile(t *testing.T) {
 	}
 }
 
+func TestResolveTargetRecognizesManifestByFilesystemIdentity(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, dir)
+	alias := filepath.Join(dir, "OPENCLAW.PLUGIN.JSON")
+	if err := os.Link(filepath.Join(dir, pluginManifestName), alias); err != nil {
+		t.Skipf("hard links unsupported: %v", err)
+	}
+	resolved, err := resolveTarget(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.kind != targetKindPlugin || resolved.id != "probe-plugin" || resolved.resolvedPath != dir {
+		t.Fatalf("resolved = %#v", resolved)
+	}
+}
+
 func TestValidPluginIDAcceptsHostGrammar(t *testing.T) {
 	valid := []string{"probe-plugin", "memory-lancedb-pro", "@scope/name", "@a/b", "Probe.Plugin_2", "has space", "caf\u00e9-plugin", strings.Repeat("a", 300)}
 	for _, id := range valid {
@@ -181,6 +197,21 @@ func TestResolveTargetExplicitPluginManifestDisambiguatesDualLayout(t *testing.T
 	}
 }
 
+func TestResolveTargetExplicitSkillManifestDisambiguatesDualLayout(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "dual-layout")
+	writeProbePlugin(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, skillManifestName), []byte("# Bundled skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := resolveTarget(filepath.Join(dir, skillManifestName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.kind != targetKindSkill || resolved.id != "" || resolved.resolvedPath != dir {
+		t.Fatalf("resolved = %#v", resolved)
+	}
+}
+
 func TestResolveTargetIgnoresSymlinkedPluginManifest(t *testing.T) {
 	// A hostile target must not be able to point openclaw.plugin.json at a host
 	// file outside the target and be classified/read as that plugin.
@@ -236,6 +267,58 @@ func TestReadPluginIDReadsRegularManifest(t *testing.T) {
 	}
 }
 
+func TestReadPluginIDAcceptsOpenClawJSON5Syntax(t *testing.T) {
+	tests := map[string]string{
+		"comment":            "{\"id\":\"probe-plugin\" // plugin identity\n}",
+		"trailing comma":     "{\"id\":\"probe-plugin\",}",
+		"unquoted key":       "{id:\"probe-plugin\"}",
+		"single quotes":      "{\"id\":'probe-plugin'}",
+		"BOM":                "\ufeff{id:'probe-plugin'}",
+		"Unicode whitespace": "{\u2003id:'probe-plugin'}",
+		"Unicode key":        "{π:true,id:'probe-plugin'}",
+		"escaped key":        `{\u0069d:'probe-plugin'}`,
+		"extended escape":    `{meta:'\v',id:'probe-plugin'}`,
+	}
+	for name, manifest := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, pluginManifestName)
+			if err := os.WriteFile(path, []byte(manifest), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			id, err := readPluginID(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if id != "probe-plugin" {
+				t.Fatalf("id = %q", id)
+			}
+		})
+	}
+}
+
+func TestReadPluginIDRequiresExactLowercaseKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, pluginManifestName)
+	if err := os.WriteFile(path, []byte(`{"ID":"probe-plugin"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if id, err := readPluginID(path); err == nil || id != "" {
+		t.Fatalf("id = %q err = %v", id, err)
+	}
+
+	if err := os.WriteFile(path, []byte(`{"id":"probe-plugin","ID":"../escape"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	id, err := readPluginID(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "probe-plugin" {
+		t.Fatalf("id = %q", id)
+	}
+}
+
 func TestResolveTargetIgnoresSymlinkManifestNextToSkill(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "mixed")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -276,7 +359,7 @@ func TestResolveTargetRejectsInvalidPluginID(t *testing.T) {
 	}
 }
 
-func TestRunDispatchesClawHubScannersForPluginTarget(t *testing.T) {
+func TestRunDispatchesCompatibleScannersForPluginTarget(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "probe-plugin")
 	writeProbePlugin(t, dir)
 	opts, err := ParseArgs([]string{

--- a/internal/runner/virustotal_scanner.go
+++ b/internal/runner/virustotal_scanner.go
@@ -79,7 +79,7 @@ func (runner ExternalScannerRunner) runVirusTotal(target string, startedAt strin
 			Raw:         nil,
 		}, nil
 	}
-	artifact, err := virusTotalArtifact(target)
+	artifact, err := virusTotalArtifact(target, runner.TargetKind, runner.TargetID)
 	if err != nil {
 		return ScannerResult{}, err
 	}
@@ -179,7 +179,7 @@ func (runner ExternalScannerRunner) runVirusTotal(target string, startedAt strin
 	}
 }
 
-func virusTotalArtifact(target string) (virusTotalScanArtifact, error) {
+func virusTotalArtifact(target string, targetKind string, targetID string) (virusTotalScanArtifact, error) {
 	info, err := os.Stat(target)
 	if err != nil {
 		return virusTotalScanArtifact{}, fmt.Errorf("stat target: %v", err)
@@ -188,10 +188,13 @@ func virusTotalArtifact(target string) (virusTotalScanArtifact, error) {
 		kind := "skill-zip"
 		filename := "skill.zip"
 		slug := filepath.Base(target)
-		if regularManifestExists(filepath.Join(target, pluginManifestName)) {
-			pluginID, err := readPluginID(filepath.Join(target, pluginManifestName))
-			if err != nil {
-				return virusTotalScanArtifact{}, fmt.Errorf("read plugin identity for VirusTotal ZIP: %w", err)
+		if targetKind == targetKindPlugin || (targetKind == "" && regularManifestExists(filepath.Join(target, pluginManifestName))) {
+			pluginID := targetID
+			if pluginID == "" {
+				pluginID, err = readPluginID(filepath.Join(target, pluginManifestName))
+				if err != nil {
+					return virusTotalScanArtifact{}, fmt.Errorf("read plugin identity for VirusTotal ZIP: %w", err)
+				}
 			}
 			kind = "plugin-zip"
 			filename = "plugin.zip"

--- a/internal/runner/virustotal_scanner.go
+++ b/internal/runner/virustotal_scanner.go
@@ -30,9 +30,10 @@ type VirusTotalHTTPClient interface {
 }
 
 type virusTotalScanArtifact struct {
-	Bytes  []byte
-	SHA256 string
-	Kind   string
+	Bytes          []byte
+	SHA256         string
+	Kind           string
+	UploadFilename string
 }
 
 type virusTotalNormalizedAnalysis struct {
@@ -188,7 +189,18 @@ func virusTotalArtifact(target string) (virusTotalScanArtifact, error) {
 		if err != nil {
 			return virusTotalScanArtifact{}, err
 		}
-		return virusTotalScanArtifact{Bytes: bytes, SHA256: sha256BytesHex(bytes), Kind: "skill-zip"}, nil
+		kind := "skill-zip"
+		filename := "skill.zip"
+		if regularManifestExists(filepath.Join(target, pluginManifestName)) {
+			kind = "plugin-zip"
+			filename = "plugin.zip"
+		}
+		return virusTotalScanArtifact{
+			Bytes:          bytes,
+			SHA256:         sha256BytesHex(bytes),
+			Kind:           kind,
+			UploadFilename: filename,
+		}, nil
 	}
 	if !info.Mode().IsRegular() {
 		return virusTotalScanArtifact{}, fmt.Errorf("VirusTotal scanner supports local file or directory targets in v1; non-regular files are unsupported")
@@ -287,7 +299,11 @@ func uploadVirusTotalArtifact(ctx context.Context, client VirusTotalHTTPClient, 
 	}
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
-	part, err := writer.CreateFormFile("file", "skill.zip")
+	filename := strings.TrimSpace(artifact.UploadFilename)
+	if filename == "" {
+		filename = "skill.zip"
+	}
+	part, err := writer.CreateFormFile("file", filename)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runner/virustotal_scanner.go
+++ b/internal/runner/virustotal_scanner.go
@@ -185,15 +185,21 @@ func virusTotalArtifact(target string) (virusTotalScanArtifact, error) {
 		return virusTotalScanArtifact{}, fmt.Errorf("stat target: %v", err)
 	}
 	if info.IsDir() {
-		bytes, err := buildVirusTotalSkillZip(target)
-		if err != nil {
-			return virusTotalScanArtifact{}, err
-		}
 		kind := "skill-zip"
 		filename := "skill.zip"
+		slug := filepath.Base(target)
 		if regularManifestExists(filepath.Join(target, pluginManifestName)) {
+			pluginID, err := readPluginID(filepath.Join(target, pluginManifestName))
+			if err != nil {
+				return virusTotalScanArtifact{}, fmt.Errorf("read plugin identity for VirusTotal ZIP: %w", err)
+			}
 			kind = "plugin-zip"
 			filename = "plugin.zip"
+			slug = pluginID
+		}
+		bytes, err := buildVirusTotalDirectoryZip(target, slug)
+		if err != nil {
+			return virusTotalScanArtifact{}, err
 		}
 		return virusTotalScanArtifact{
 			Bytes:          bytes,
@@ -358,6 +364,10 @@ func virusTotalUploadURL(ctx context.Context, client VirusTotalHTTPClient, apiKe
 }
 
 func buildVirusTotalSkillZip(root string) ([]byte, error) {
+	return buildVirusTotalDirectoryZip(root, filepath.Base(root))
+}
+
+func buildVirusTotalDirectoryZip(root string, slug string) ([]byte, error) {
 	var files []string
 	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
@@ -407,7 +417,7 @@ func buildVirusTotalSkillZip(root string) ([]byte, error) {
 			return nil, err
 		}
 	}
-	meta, err := virusTotalSkillMeta(root)
+	meta, err := virusTotalSkillMeta(slug)
 	if err != nil {
 		return nil, err
 	}
@@ -435,10 +445,10 @@ func newFlateWriter(w io.Writer) (io.WriteCloser, error) {
 	return flate.NewWriter(w, 6)
 }
 
-func virusTotalSkillMeta(root string) ([]byte, error) {
+func virusTotalSkillMeta(slug string) ([]byte, error) {
 	meta := map[string]interface{}{
 		"ownerId":     "clawscan",
-		"slug":        filepath.Base(root),
+		"slug":        slug,
 		"version":     "0.0.0",
 		"publishedAt": float64(0),
 	}

--- a/internal/runner/virustotal_scanner.go
+++ b/internal/runner/virustotal_scanner.go
@@ -23,7 +23,7 @@ const (
 	virusTotalDirectUploadLimit = 32 * 1024 * 1024
 )
 
-var virusTotalFixedZipDate = time.Date(1980, 1, 1, 0, 0, 0, 0, time.Local)
+var virusTotalFixedZipDate = time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
 
 type VirusTotalHTTPClient interface {
 	Do(request *http.Request) (*http.Response, error)

--- a/internal/runner/virustotal_scanner_test.go
+++ b/internal/runner/virustotal_scanner_test.go
@@ -136,6 +136,51 @@ func TestVirusTotalScannerScansDirectoryTargetsAsSkillZip(t *testing.T) {
 	}
 }
 
+func TestVirusTotalScannerScansPluginDirectoryAsPluginZip(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "probe-plugin")
+	writeProbePlugin(t, target)
+	scanArtifact, err := virusTotalArtifact(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scanArtifact.Kind != "plugin-zip" || scanArtifact.UploadFilename != "plugin.zip" {
+		t.Fatalf("scan artifact = %#v", scanArtifact)
+	}
+	expectedSHA := scanArtifact.SHA256
+	vtJSON := `{"data":{"id":"` + expectedSHA + `","type":"file","attributes":{"last_analysis_stats":{"malicious":0,"suspicious":0,"harmless":3,"undetected":70}}}}`
+	client := &recordingHTTPClient{
+		response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(vtJSON)),
+		},
+	}
+	manifestTarget := filepath.Join(target, pluginManifestName)
+	opts, err := ParseArgs([]string{manifestTarget, "--scanner", "virustotal", "--sandbox", "off"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := Run(opts, RunContext{
+		Env:                  map[string]string{"VIRUSTOTAL_API_KEY": "present"},
+		VirusTotalHTTPClient: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := artifact.Scanners["virustotal"]
+	if result.Status != "completed" {
+		t.Fatalf("status = %q error = %q", result.Status, result.Error)
+	}
+	if !containsArg(result.Command, "plugin-zip") || containsArg(result.Command, "skill-zip") {
+		t.Fatalf("command = %#v", result.Command)
+	}
+	if artifact.Target.Kind != targetKindPlugin || artifact.Target.ID != "probe-plugin" {
+		t.Fatalf("target = %#v", artifact.Target)
+	}
+	if artifact.Target.ResolvedPath != target {
+		t.Fatalf("resolved path = %q, want full plugin directory %q", artifact.Target.ResolvedPath, target)
+	}
+}
+
 func TestVirusTotalScannerSkipsURLTargets(t *testing.T) {
 	target := "https://clawhub.ai/author/skill"
 	client := &recordingHTTPClient{err: errUnexpectedHTTPRequest}

--- a/internal/runner/virustotal_scanner_test.go
+++ b/internal/runner/virustotal_scanner_test.go
@@ -181,6 +181,23 @@ func TestVirusTotalScannerScansPluginDirectoryAsPluginZip(t *testing.T) {
 	}
 }
 
+func TestVirusTotalPluginZipUsesStableManifestIdentity(t *testing.T) {
+	root := t.TempDir()
+	var artifacts []virusTotalScanArtifact
+	for _, checkout := range []string{"checkout-a", "checkout-b"} {
+		target := filepath.Join(root, checkout)
+		writeProbePlugin(t, target)
+		artifact, err := virusTotalArtifact(target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	if artifacts[0].SHA256 != artifacts[1].SHA256 {
+		t.Fatalf("plugin ZIP hash depends on checkout directory: %q != %q", artifacts[0].SHA256, artifacts[1].SHA256)
+	}
+}
+
 func TestVirusTotalScannerSkipsURLTargets(t *testing.T) {
 	target := "https://clawhub.ai/author/skill"
 	client := &recordingHTTPClient{err: errUnexpectedHTTPRequest}

--- a/internal/runner/virustotal_scanner_test.go
+++ b/internal/runner/virustotal_scanner_test.go
@@ -146,7 +146,7 @@ func TestVirusTotalScannerScansDirectoryTargetsAsSkillZip(t *testing.T) {
 func TestVirusTotalScannerScansPluginDirectoryAsPluginZip(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "probe-plugin")
 	writeProbePlugin(t, target)
-	scanArtifact, err := virusTotalArtifact(target)
+	scanArtifact, err := virusTotalArtifact(target, targetKindPlugin, "probe-plugin")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,13 +188,47 @@ func TestVirusTotalScannerScansPluginDirectoryAsPluginZip(t *testing.T) {
 	}
 }
 
+func TestVirusTotalRespectsExplicitSkillInDualLayoutPackage(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "dual-layout")
+	writeProbePlugin(t, target)
+	if err := os.WriteFile(filepath.Join(target, skillManifestName), []byte("# Bundled skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skillZip, err := buildVirusTotalDirectoryZip(target, filepath.Base(target))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSHA := sha256BytesHex(skillZip)
+	client := &recordingHTTPClient{
+		response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"attributes":{"last_analysis_stats":{"malicious":0}}}}`)),
+		},
+	}
+	opts, err := ParseArgs([]string{filepath.Join(target, skillManifestName), "--scanner", "virustotal", "--sandbox", "off"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := Run(opts, RunContext{
+		Env:                  map[string]string{"VIRUSTOTAL_API_KEY": "present"},
+		VirusTotalHTTPClient: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := artifact.Scanners["virustotal"]
+	if artifact.Target.Kind != targetKindSkill || !containsArg(result.Command, "skill-zip") || containsArg(result.Command, "plugin-zip") || !containsArg(result.Command, "sha256:"+expectedSHA) {
+		t.Fatalf("target = %#v command = %#v", artifact.Target, result.Command)
+	}
+}
+
 func TestVirusTotalPluginZipUsesStableManifestIdentity(t *testing.T) {
 	root := t.TempDir()
 	var artifacts []virusTotalScanArtifact
 	for _, checkout := range []string{"checkout-a", "checkout-b"} {
 		target := filepath.Join(root, checkout)
 		writeProbePlugin(t, target)
-		artifact, err := virusTotalArtifact(target)
+		artifact, err := virusTotalArtifact(target, targetKindPlugin, "probe-plugin")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/runner/virustotal_scanner_test.go
+++ b/internal/runner/virustotal_scanner_test.go
@@ -9,7 +9,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestVirusTotalZipTimestampIsTimezoneIndependent(t *testing.T) {
+	if virusTotalFixedZipDate.Location() != time.UTC {
+		t.Fatalf("fixed ZIP timestamp location = %v, want UTC", virusTotalFixedZipDate.Location())
+	}
+}
 
 func TestRunExecutesVirusTotalScannerForSingleFile(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- Add explicit OpenClaw plugin directory and manifest targets with stable identity, ambiguity handling, symlink-hardened reads, and OpenClaw-compatible JSON5 parsing.
- Run the current built-in `clawhub` scanners, SkillSpector and ClawScan Static, for plugins and provide `packageRelease` context to the bundled judge.
- Keep Socket and VirusTotal available for explicit selection and custom profiles, while skill-only scanners return an explicit `skipped` result for plugin targets.
- Scan complete plugin directories, preserve explicit skill or plugin selection in dual-layout packages, and build deterministic `plugin.zip` artifacts for VirusTotal.

## Root Cause

Before this PR, target resolution recognized only skills and URLs. Scanner capability checks and artifact metadata had no plugin target kind, so OpenClaw plugin manifests were routed through skill assumptions.

The original PR head also decoded `openclaw.plugin.json` with strict `encoding/json`. ClawSweeper reproduced that comments, trailing commas, and unquoted keys accepted by OpenClaw failed before scanner dispatch. Inspection of OpenClaw's manifest loader confirmed a strict-JSON first pass with JSON5 fallback.

During review, dual-layout packages exposed two related classification gaps: explicit `SKILL.md` narrowed the scan to one file, and VirusTotal independently reclassified the enclosing directory from its contents. The final implementation carries resolved target kind and ID into scanner dispatch and recognizes explicit manifests by filesystem identity.

## Security / Trust Impact

Plugin contents remain untrusted. Manifest discovery does not follow symlinks; reads use `O_NOFOLLOW`, a same-file check, and a 256 KiB cap. The exact lowercase `id` key is required and validated before it enters artifacts or ZIP metadata. A directory containing both manifests fails closed until the caller selects the intended manifest.

VirusTotal can upload a deterministic archive when explicitly selected or included in a custom profile. Operators should not submit confidential packages to a public VirusTotal corpus.

## Real behavior proof

Closest feasible host behavior on the final head:

```
go test -count=1 ./internal/runner -run 'TestReadPluginIDAcceptsOpenClawJSON5Syntax|TestVirusTotalRespectsExplicitSkillInDualLayoutPackage|TestResolveTargetExplicit(Skill|Plugin)ManifestDisambiguatesDualLayout' -v
PASS
ok github.com/openclaw/clawscan/internal/runner 0.010s
```

The JSON5 test passed comments, trailing commas, unquoted and escaped keys, single quotes, BOM, Unicode whitespace and keys, and extended escapes.

A real first-party plugin from an OpenClaw checkout was then scanned with the final binary. The checkout prefix is redacted:

```
go run ./cmd/clawscan "$OPENCLAW_REPO/extensions/synology-chat/openclaw.plugin.json" --scanner clawscan-static --json
```

Observed result:

```json
{
  "target": {"kind":"plugin","id":"synology-chat"},
  "status": "completed",
  "scanned": 25,
  "omitted": 0
}
```

Current profile behavior was also checked with `go run ./cmd/clawscan profiles -v`; `clawhub` lists exactly `skillspector` and `clawscan-static`.

## Verification

- [x] `go test -count=1 ./...`
- [x] `go test -race -count=1 ./...`
- [x] `go vet ./...`
- [x] `make docs-site`, built 6 pages
- [x] CGO-disabled builds: Darwin amd64/arm64, Linux amd64/arm64, Windows amd64
- [x] `git diff --check`
- [x] `go mod tidy -diff`
- [x] Focused JSON5, dual-layout, symlink discovery, filesystem identity, and VirusTotal target-kind regressions
- [x] GPT-5.6-SOL xhigh repo autoreview and independent closeout review; all reproduced code findings fixed and rerun
- [x] Remaining repeated VirusTotal profile finding rejected against the live profile file, CLI output, and resolver regression test

## What was not tested

- A live network-backed VirusTotal upload was not rerun after the final JSON5 and target-kind fixes; request, hashing, upload, and response behavior remains fixture-backed.
- A live full SkillSpector plus Codex judge run was not repeated after the final parser-only and dispatch-context fixes; the real plugin static scan and complete unit/race suites were rerun.
- Case-insensitive filesystem behavior was not exercised on a native Windows or macOS volume; filesystem-identity regression coverage and all target cross-builds passed.

## Scope boundary

Plugins remain explicit targets and are not added to zero-target skill discovery. Benchmark behavior, release automation, and unrelated scanner behavior are unchanged.