### PR TITLE
chore: align pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,36 +1,65 @@
-## Summary
+<!--
+Optional linked context:
+Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
+below this comment.
 
-- What changed:
-- Why:
+Required PR title:
+type: user-facing description
+Use a parenthesized scope only when it adds clarity:
+fix(auth): login redirect loops when session cookie is expired
 
-## Scope
+Types: feat, fix, improve, refactor, docs, chore.
+For fixes, describe the user-visible symptom and trigger:
+fix: task list fails to load when user has no environments
+Avoid implementation details such as:
+fix: add null check to task query
+-->
 
-- [ ] CLI behavior
-- [ ] Scanner adapter
-- [ ] Judge/profile/benchmark behavior
-- [ ] ClawHub profile proposal at `proposals/<GHSA-ID>/clawscan.yml`
-- [ ] Docs only
-- [ ] Release/CI/repo automation
+<details>
+<summary>Additional instructions</summary>
 
-## Security / Trust Impact
+**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
+can help update the branch when needed.
 
-- [ ] No security/trust impact
-- [ ] Security/trust impact explained
+</details>
 
-Explain any effect on scanner execution, judge commands, prompt/schema handling,
-secret redaction, benchmark submissions, or generated artifacts.
+## What Problem This Solves
 
-## Verification
+<!--
+Describe the concrete user, product, or operational problem.
+For fixes, begin with:
+"Fixes an issue where users <do X> would <experience Y> when <condition>."
+or:
+"Resolves a problem where..."
 
-- [ ] `go test -count=1 ./...`
-- [ ] `go vet ./...`
-- [ ] `go run ./cmd/clawscan --help`
-- [ ] Focused scanner/benchmark/manual proof:
-- [ ] For ClawHub profile proposals: I opened the sensitive report through GitHub private vulnerability reporting, and this PR contains only `proposals/<GHSA-ID>/clawscan.yml`
-- [ ] For ClawHub profile proposals: I did not edit official bundled profile files under `internal/profiles/`
-- [ ] Docs site proof (`make docs-site`) or `N/A`:
+Name the affected UI surface or workflow. Do not describe the code-level cause here.
+-->
 
-## Notes
+## Why This Change Was Made
 
-List any live scanner credentials, external services, benchmark datasets, or
-release steps intentionally skipped.
+<!--
+In one or two sentences, explain the complete shipped solution, key design
+decisions, and relevant boundaries or non-goals. Include implementation detail
+only when it helps reviewers understand user-visible behavior or risk.
+Avoid file-by-file narration.
+-->
+
+## User Impact
+
+<!--
+State what users, operators, or developers can now do or expect. Lead with the
+concrete benefit and use user-facing language. If there is no user-visible
+impact, say so plainly.
+-->
+
+## Evidence
+
+<!--
+Show the most useful proof that this change works. Screenshots, screencasts,
+terminal output, focused tests, CI results, live observations, redacted logs,
+and artifact links are all useful. Include before/after evidence for visual
+changes when it clarifies the result.
+
+Reviewers will inspect the code, tests, and CI. Use this section to make the
+validation easy to understand, not to restate the diff.
+-->


### PR DESCRIPTION
## What Problem This Solves
Resolves inconsistent pull request descriptions across OpenClaw-owned repositories, which makes cross-repository review and evidence collection less predictable.

## Why This Change Was Made
Copies the canonical PR body template from `openclaw/openclaw` at pinned commit `2ac723282c84286ad3f38aabbd2e70699aafb3c3` (blob `e902c4789b21765ea16dfb75e436db5801b6450b`, SHA-256 `38845d7f2cfc96402062408ac8a87b1e3f5f81dd80924785b0547b64a0c914b6`) to standardize how pull requests describe the problem, rationale, impact, and evidence.

## User Impact
Contributors and maintainers get the same PR submission structure across OpenClaw-owned repositories. No runtime behavior changes.

## Evidence
The committed `.github/pull_request_template.md` matches the pinned `openclaw/openclaw` source: commit `2ac723282c84286ad3f38aabbd2e70699aafb3c3`, blob `e902c4789b21765ea16dfb75e436db5801b6450b`, and SHA-256 `38845d7f2cfc96402062408ac8a87b1e3f5f81dd80924785b0547b64a0c914b6`. This is metadata-only; no runtime tests were run. AI-assisted batch maintenance change.