### PR TITLE
fix: require verified artifact inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Supported `--judge` placeholders:
 | Placeholder | Meaning |
 | --- | --- |
 | `{{ workspace }}` | Temporary directory containing the copied skill, scanner JSON, and metadata. |
+| `{{ judge_sandbox }}` | `danger-full-access` inside ClawScan's Docker sandbox, otherwise `read-only`. |
 | `{{ prompt }}` | Render `./prompt.md` and pass the rendered prompt file path. |
 | `{{ prompt:<path> }}` | Render a specific prompt template and pass that file path. |
 | `{{ output_schema }}` | Copy `./schema.json` into the workspace and pass that file path. |

--- a/cmd/clawscan/main_test.go
+++ b/cmd/clawscan/main_test.go
@@ -507,7 +507,7 @@ func TestRunCommandUsesBuiltInProfile(t *testing.T) {
 			"--profile", "clawhub",
 			"--scanner-result", "skillspector=" + skillSpectorFixture,
 			"--scanner-result", "virustotal=" + virusTotalFixture,
-			"--judge", "printf '{\"verdict\":\"benign\"}\\n' > {{ output }}",
+			"--judge", clawHubReceiptJudgeCommand(),
 			"--sandbox", "off",
 			"--json",
 		}, []string{}); err != nil {
@@ -551,7 +551,7 @@ func TestRunCommandDiscoversSkillsWithExplicitProfile(t *testing.T) {
 			"--profile", "clawhub",
 			"--scanner-result", "skillspector=" + skillSpectorFixture,
 			"--scanner-result", "virustotal=" + virusTotalFixture,
-			"--judge", "printf '{\"verdict\":\"benign\"}\\n' > {{ output }}",
+			"--judge", clawHubReceiptJudgeCommand(),
 			"--sandbox", "off",
 			"--json",
 		}, []string{}); err != nil {
@@ -589,6 +589,10 @@ func TestRunCommandDiscoversSkillsWithExplicitProfile(t *testing.T) {
 			t.Fatalf("missing clawscan-static scanner for %s: %#v", run.Target.Input, run.Scanners)
 		}
 	}
+}
+
+func clawHubReceiptJudgeCommand() string {
+	return `challenge=$(sed -n 's/.*"challenge": "\([^"]*\)".*/\1/p' {{ workspace }}/artifact-inspection.json); required_file=$(sed -n 's/.*"required_file": "\([^"]*\)".*/\1/p' {{ workspace }}/artifact-inspection.json); if command -v sha256sum >/dev/null 2>&1; then required_sha=$(sha256sum {{ workspace }}/"$required_file" | cut -d ' ' -f 1); else required_sha=$(shasum -a 256 {{ workspace }}/"$required_file" | cut -d ' ' -f 1); fi; printf '{"verdict":"benign","artifact_inspection":{"status":"completed","challenge":"%s","required_file_sha256":"%s","files_inspected":["%s"]}}\n' "$challenge" "$required_sha" "$required_file" > {{ output }}`
 }
 
 func TestRunCommandUsesProjectProfile(t *testing.T) {

--- a/docs/judge.md
+++ b/docs/judge.md
@@ -15,6 +15,7 @@ Supported `--judge` placeholders:
 | Placeholder | Meaning |
 | --- | --- |
 | `{{ workspace }}` | Temporary directory containing the copied skill, scanner JSON, and metadata. |
+| `{{ judge_sandbox }}` | `danger-full-access` inside ClawScan's Docker sandbox, otherwise `read-only`. |
 | `{{ prompt }}` | Render `./prompt.md` and pass the rendered prompt file path. |
 | `{{ prompt:<path> }}` | Render a specific prompt template and pass that file path. |
 | `{{ output_schema }}` | Copy `./schema.json` into the workspace and pass that file path. |

--- a/internal/profiles/clawhub/clawscan.yml
+++ b/internal/profiles/clawhub/clawscan.yml
@@ -16,7 +16,7 @@ profiles:
       command: >-
         codex exec --cd {{ workspace }}
         --model gpt-5.5
-        --sandbox read-only
+        --sandbox {{ judge_sandbox }}
         --skip-git-repo-check
         --ignore-user-config
         -c approval_policy=never
@@ -43,7 +43,7 @@ profiles:
       command: >-
         codex exec --cd {{ workspace }}
         --model gpt-5.5
-        --sandbox read-only
+        --sandbox {{ judge_sandbox }}
         --skip-git-repo-check
         --ignore-user-config
         -c approval_policy=never

--- a/internal/profiles/clawhub/output.schema.json
+++ b/internal/profiles/clawhub/output.schema.json
@@ -7,7 +7,8 @@
     "summary",
     "dimensions",
     "scan_findings_in_context",
-    "user_guidance"
+    "user_guidance",
+    "artifact_inspection"
   ],
   "properties": {
     "verdict": { "type": "string", "enum": ["benign", "suspicious", "malicious"] },
@@ -84,6 +85,24 @@
         }
       }
     },
-    "user_guidance": { "type": "string" }
+    "user_guidance": { "type": "string" },
+    "artifact_inspection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "challenge", "required_file_sha256", "files_inspected"],
+      "properties": {
+        "status": { "type": "string", "enum": ["completed"] },
+        "challenge": { "type": "string", "minLength": 1 },
+        "required_file_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "files_inspected": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "pattern": "^artifact/" }
+        }
+      }
+    }
   }
 }

--- a/internal/profiles/clawhub/prompt.md
+++ b/internal/profiles/clawhub/prompt.md
@@ -10,6 +10,8 @@ The internal verdict value "suspicious" is the user-facing Review bucket, not an
 
 Before using the Review bucket, identify concrete artifact evidence showing purpose-mismatched behavior, hidden behavior, overbroad authority, deceptive framing, unsafe automatic execution, unbounded persistence, unexpected credential/data handling, or high-impact actions without clear user control. Do not escalate from a scanner label alone.
 
+You must inspect the workspace before returning a verdict. Read `artifact-inspection.json`, inspect and SHA-256 hash its `required_file`, and copy the exact challenge value into `artifact_inspection.challenge`. Include the required file and any other files you inspected in `artifact_inspection.files_inspected`. Never guess or copy a challenge or hash from the prompt. If you cannot read the challenge file or required artifact file, do not claim inspection completed and do not return a security verdict.
+
 Purpose-aligned behavior can still be a Review concern when it grants high-impact authority without clear scoping, reversibility, containment, or user-directed control. Treat these as material concern candidates: modifying or deleting financial/business/account data, posting or moderating public content, bulk-changing installed skills or agent behavior, indexing broad local/private content for reuse, spawning background agents or long-running workers, reading or using local auth/session/profile stores, or using raw API/escape-hatch commands that bypass safer scoped workflows.
 
 Do not classify a skill as suspicious only because it uses files, commands, credentials, network access, memory, package installs, provider APIs, or external tools. Judge whether those behaviors are coherent with the stated purpose and clearly disclosed.
@@ -42,7 +44,13 @@ Respond with a JSON object and nothing else:
   "scan_findings_in_context": [
     { "ruleId": "...", "expected_for_purpose": true | false, "note": "..." }
   ],
-  "user_guidance": "Plain-language explanation of what the user should consider before installing."
+  "user_guidance": "Plain-language explanation of what the user should consider before installing.",
+  "artifact_inspection": {
+    "status": "completed",
+    "challenge": "Exact challenge read from artifact-inspection.json",
+    "required_file_sha256": "SHA-256 of the required artifact file",
+    "files_inspected": ["artifact/SKILL.md"]
+  }
 }
 
 Additional ClawHub policy for this Codex run:

--- a/internal/profiles/resolver_test.go
+++ b/internal/profiles/resolver_test.go
@@ -29,6 +29,9 @@ func TestResolveArgsUsesEmbeddedClawHubProfile(t *testing.T) {
 	if !strings.Contains(opts.Judge.Command, "codex exec") {
 		t.Fatalf("judge command = %q", opts.Judge.Command)
 	}
+	if !strings.Contains(opts.Judge.Command, "--sandbox {{ judge_sandbox }}") {
+		t.Fatalf("judge command missing runtime-aware sandbox placeholder: %q", opts.Judge.Command)
+	}
 	if strings.Contains(opts.Judge.Command, "{{ prompt:prompt.md }}") {
 		t.Fatalf("judge command kept unresolved profile-local prompt placeholder: %q", opts.Judge.Command)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -422,7 +423,7 @@ func Run(opts Options, ctx RunContext) (Artifact, error) {
 		artifact.Scanners[scanner] = result
 	}
 	if opts.Judge != nil {
-		result, err := RunJudge(*opts.Judge, artifact, commandRunner, 20*time.Minute, env)
+		result, err := RunJudge(*opts.Judge, artifact, commandRunner, 20*time.Minute, env, sandbox.Mode)
 		if err != nil {
 			return Artifact{}, err
 		}
@@ -1082,6 +1083,7 @@ func sha256Hex(value string) string {
 
 type judgeCommandState struct {
 	workspace        string
+	judgeSandbox     string
 	outputPath       string
 	outputUsed       bool
 	promptSource     string
@@ -1091,6 +1093,7 @@ type judgeCommandState struct {
 	outputSchemaSHA  string
 	schemaSource     string
 	files            map[string][]byte
+	inspection       *artifactInspectionChallenge
 }
 
 type judgeShellSpec struct {
@@ -1099,7 +1102,7 @@ type judgeShellSpec struct {
 	quote   func(string) string
 }
 
-func RunJudge(opts JudgeOptions, artifact Artifact, commandRunner CommandRunner, timeout time.Duration, env map[string]string) (*JudgeResult, error) {
+func RunJudge(opts JudgeOptions, artifact Artifact, commandRunner CommandRunner, timeout time.Duration, env map[string]string, sandboxMode string) (*JudgeResult, error) {
 	workspace, err := os.MkdirTemp("", "clawscan-judge-*")
 	if err != nil {
 		return nil, err
@@ -1112,12 +1115,17 @@ func RunJudge(opts JudgeOptions, artifact Artifact, commandRunner CommandRunner,
 		timeout = 20 * time.Minute
 	}
 	state := &judgeCommandState{
-		workspace:  workspace,
-		outputPath: filepath.Join(workspace, "judge-output.json"),
-		files:      opts.Files,
+		workspace:    workspace,
+		judgeSandbox: judgeSandboxMode(sandboxMode),
+		outputPath:   filepath.Join(workspace, "judge-output.json"),
+		files:        opts.Files,
 	}
 	if isClawHubParityProfile(artifact.Profile) {
 		state.outputPath = filepath.Join(workspace, "codex-result.json")
+		state.inspection, err = prepareArtifactInspectionChallenge(workspace)
+		if err != nil {
+			return nil, err
+		}
 	}
 	shell := judgeShellForGOOS(runtime.GOOS)
 	command, err := renderJudgeCommand(opts.Command, artifact, state, shell.quote)
@@ -1168,14 +1176,139 @@ func RunJudge(opts JudgeOptions, artifact Artifact, commandRunner CommandRunner,
 		return result, nil
 	}
 	parsed = redactJudgeResult(parsed, env)
-	if _, ok := parsed.(map[string]any); !ok {
+	parsedObject, ok := parsed.(map[string]any)
+	if !ok {
 		result.Status = "failed"
 		result.Error = fmt.Sprintf("Judge command produced %s; expected JSON object.", judgeJSONType(parsed))
 		result.Result = parsed
 		return result, nil
 	}
 	result.Result = parsed
+	if state.inspection != nil {
+		if err := validateArtifactInspectionReceipt(parsedObject, *state.inspection); err != nil {
+			result.Status = "failed"
+			result.Error = err.Error()
+		}
+	}
 	return result, nil
+}
+
+func judgeSandboxMode(outerSandboxMode string) string {
+	if outerSandboxMode == SandboxModeDocker {
+		return "danger-full-access"
+	}
+	return "read-only"
+}
+
+type artifactInspectionChallenge struct {
+	Challenge      string `json:"challenge"`
+	RequiredFile   string `json:"required_file"`
+	RequiredSHA256 string `json:"-"`
+}
+
+func prepareArtifactInspectionChallenge(workspace string) (*artifactInspectionChallenge, error) {
+	random := make([]byte, 32)
+	if _, err := rand.Read(random); err != nil {
+		return nil, fmt.Errorf("generate artifact inspection challenge: %w", err)
+	}
+	requiredFile, requiredSHA256, err := selectArtifactInspectionFile(workspace)
+	if err != nil {
+		return nil, err
+	}
+	challenge := &artifactInspectionChallenge{
+		Challenge:      hex.EncodeToString(random),
+		RequiredFile:   requiredFile,
+		RequiredSHA256: requiredSHA256,
+	}
+	raw, err := json.MarshalIndent(challenge, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	raw = append(raw, '\n')
+	if err := os.WriteFile(filepath.Join(workspace, "artifact-inspection.json"), raw, 0o600); err != nil {
+		return nil, fmt.Errorf("write artifact inspection challenge: %w", err)
+	}
+	return challenge, nil
+}
+
+func selectArtifactInspectionFile(workspace string) (string, string, error) {
+	artifactDir := filepath.Join(workspace, "artifact")
+	candidates := []string{}
+	for _, preferred := range []string{"SKILL.md", "package.json"} {
+		info, err := os.Stat(filepath.Join(artifactDir, preferred))
+		if err == nil && info.Mode().IsRegular() {
+			candidates = append(candidates, preferred)
+		}
+	}
+	if len(candidates) == 0 {
+		err := filepath.WalkDir(artifactDir, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.Type().IsRegular() {
+				relative, err := filepath.Rel(artifactDir, path)
+				if err != nil {
+					return err
+				}
+				candidates = append(candidates, relative)
+			}
+			return nil
+		})
+		if err != nil {
+			return "", "", fmt.Errorf("select artifact inspection file: %w", err)
+		}
+	}
+	if len(candidates) == 0 {
+		return "", "", errors.New("artifact inspection requires at least one regular artifact file")
+	}
+	sort.Strings(candidates)
+	relative := candidates[0]
+	file, err := os.Open(filepath.Join(artifactDir, relative))
+	if err != nil {
+		return "", "", fmt.Errorf("open artifact inspection file: %w", err)
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", "", fmt.Errorf("hash artifact inspection file: %w", err)
+	}
+	return "artifact/" + filepath.ToSlash(relative), hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func validateArtifactInspectionReceipt(result map[string]any, expected artifactInspectionChallenge) error {
+	inspection, ok := result["artifact_inspection"].(map[string]any)
+	if !ok {
+		return errors.New("Judge did not provide the required artifact inspection receipt.")
+	}
+	if status, _ := inspection["status"].(string); status != "completed" {
+		return fmt.Errorf("Judge artifact inspection status was %q; expected completed.", status)
+	}
+	challenge, _ := inspection["challenge"].(string)
+	if challenge != expected.Challenge {
+		return errors.New("Judge artifact inspection challenge did not match the workspace challenge.")
+	}
+	requiredSHA256, _ := inspection["required_file_sha256"].(string)
+	if requiredSHA256 != expected.RequiredSHA256 {
+		return errors.New("Judge artifact inspection file hash did not match the required artifact file.")
+	}
+	files, ok := inspection["files_inspected"].([]any)
+	if !ok || len(files) == 0 {
+		return errors.New("Judge artifact inspection did not report any inspected artifact files.")
+	}
+	requiredFileInspected := false
+	for _, value := range files {
+		file, ok := value.(string)
+		if !ok || !strings.HasPrefix(filepath.ToSlash(filepath.Clean(file)), "artifact/") {
+			return fmt.Errorf("Judge artifact inspection reported invalid file path %q.", value)
+		}
+		if filepath.ToSlash(filepath.Clean(file)) == expected.RequiredFile {
+			requiredFileInspected = true
+		}
+	}
+	if !requiredFileInspected {
+		return fmt.Errorf("Judge artifact inspection did not include required file %s.", expected.RequiredFile)
+	}
+	return nil
 }
 
 func judgeJSONType(value any) string {
@@ -1214,6 +1347,12 @@ func renderJudgeCommand(command string, artifact Artifact, state *judgeCommandSt
 				return match
 			}
 			return quote(state.workspace)
+		case "judge_sandbox":
+			if value != "" {
+				renderErr = fmt.Errorf("{{ judge_sandbox }} does not accept a value")
+				return match
+			}
+			return quote(state.judgeSandbox)
 		case "output":
 			if value != "" {
 				renderErr = fmt.Errorf("{{ output }} does not accept a path")

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2695,6 +2695,9 @@ func TestRunExecutesJudgeCommandWithVirtualPromptAndSchemaFiles(t *testing.T) {
 	if err := os.Mkdir(target, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("# Demo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	promptTemplate := "ClawHub judge\n\nAdditional ClawHub policy for this Codex run:\nold generated block"
 	schema := `{"type":"object"}`
 	skillSpectorJSON := `{"status":"clean"}`
@@ -2726,7 +2729,26 @@ func TestRunExecutesJudgeCommandWithVirtualPromptAndSchemaFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	judgeRunner := &recordingCommandRunner{writeOutput: `{"verdict":"benign"}`}
+	judgeRunner := &recordingCommandRunner{}
+	judgeRunner.runHook = func(_ string, _ []string, cwd string) error {
+		raw, err := os.ReadFile(filepath.Join(cwd, "artifact-inspection.json"))
+		if err != nil {
+			return err
+		}
+		var receipt struct {
+			Challenge    string `json:"challenge"`
+			RequiredFile string `json:"required_file"`
+		}
+		if err := json.Unmarshal(raw, &receipt); err != nil {
+			return err
+		}
+		required, err := os.ReadFile(filepath.Join(cwd, filepath.FromSlash(receipt.RequiredFile)))
+		if err != nil {
+			return err
+		}
+		judgeRunner.writeOutput = fmt.Sprintf(`{"verdict":"benign","artifact_inspection":{"status":"completed","challenge":%q,"required_file_sha256":%q,"files_inspected":[%q]}}`, receipt.Challenge, sha256Hex(string(required)), receipt.RequiredFile)
+		return nil
+	}
 	artifact, err := Run(opts, RunContext{
 		Env: map[string]string{"OPENAI_API_KEY": "present"},
 		ScannerRunner: staticScannerRunner{results: map[string]ScannerResult{
@@ -2755,6 +2777,159 @@ func TestRunExecutesJudgeCommandWithVirtualPromptAndSchemaFiles(t *testing.T) {
 	}
 	if filepath.Base(artifact.Judge.OutputPath) != "codex-result.json" {
 		t.Fatalf("output path = %q", artifact.Judge.OutputPath)
+	}
+}
+
+func TestRunJudgeUsesDockerAsTheCodexSandboxBoundary(t *testing.T) {
+	tests := []struct {
+		name        string
+		sandboxMode string
+		want        string
+	}{
+		{name: "docker", sandboxMode: SandboxModeDocker, want: "danger-full-access"},
+		{name: "off", sandboxMode: SandboxModeOff, want: "read-only"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "skill")
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			runner := &recordingCommandRunner{writeOutput: `{"ok":true}`}
+			artifact, err := Run(Options{
+				Target:   target,
+				Scanners: []string{"clawscan-static"},
+				Sandbox:  SandboxOptions{Mode: test.sandboxMode},
+				Judge: &JudgeOptions{
+					Command: "judge --sandbox {{ judge_sandbox }} --output {{ output }}",
+				},
+			}, RunContext{
+				Env:           map[string]string{},
+				ScannerRunner: staticScannerRunner{results: map[string]ScannerResult{"clawscan-static": {Status: "completed", Raw: json.RawMessage(`{}`)}}},
+				CommandRunner: runner,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if artifact.Judge == nil || artifact.Judge.Status != "completed" {
+				t.Fatalf("judge = %#v", artifact.Judge)
+			}
+			command := strings.Join(runner.calls[0].args, " ")
+			if !strings.Contains(command, "--sandbox '"+test.want+"'") {
+				t.Fatalf("command = %q, want sandbox %q", command, test.want)
+			}
+		})
+	}
+}
+
+func TestRunClawHubJudgeRequiresArtifactInspectionReceipt(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "skill")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("# Demo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	commandRunner := &recordingCommandRunner{
+		writeOutput: `{
+			"verdict":"benign",
+			"confidence":"high",
+			"summary":"Safe.",
+			"dimensions":{},
+			"scan_findings_in_context":[],
+			"user_guidance":"Review before use.",
+			"artifact_inspection":{
+				"status":"completed",
+				"challenge":"wrong",
+				"required_file_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"files_inspected":["artifact/SKILL.md"]
+			}
+		}`,
+	}
+	artifact, err := Run(Options{
+		Target:   target,
+		Profile:  clawHubProfileID,
+		Scanners: []string{"clawscan-static"},
+		Judge: &JudgeOptions{
+			Command: "judge --output {{ output }}",
+		},
+	}, RunContext{
+		Env:           map[string]string{},
+		ScannerRunner: staticScannerRunner{results: map[string]ScannerResult{"clawscan-static": {Status: "completed", Raw: json.RawMessage(`{}`)}}},
+		CommandRunner: commandRunner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Judge == nil || artifact.Judge.Status != "failed" {
+		t.Fatalf("judge = %#v", artifact.Judge)
+	}
+	if !strings.Contains(artifact.Judge.Error, "artifact inspection challenge") {
+		t.Fatalf("judge error = %q", artifact.Judge.Error)
+	}
+}
+
+func TestRunClawHubJudgeAcceptsVerifiedArtifactInspectionReceipt(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "skill")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "SKILL.md"), []byte("# Demo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	commandRunner := &recordingCommandRunner{}
+	commandRunner.runHook = func(_ string, _ []string, cwd string) error {
+		raw, err := os.ReadFile(filepath.Join(cwd, "artifact-inspection.json"))
+		if err != nil {
+			return err
+		}
+		var receipt struct {
+			Challenge    string `json:"challenge"`
+			RequiredFile string `json:"required_file"`
+		}
+		if err := json.Unmarshal(raw, &receipt); err != nil {
+			return err
+		}
+		required, err := os.ReadFile(filepath.Join(cwd, filepath.FromSlash(receipt.RequiredFile)))
+		if err != nil {
+			return err
+		}
+		commandRunner.writeOutput = fmt.Sprintf(`{
+			"verdict":"benign",
+			"confidence":"high",
+			"summary":"Safe.",
+			"dimensions":{},
+			"scan_findings_in_context":[],
+			"user_guidance":"Review before use.",
+			"artifact_inspection":{
+				"status":"completed",
+				"challenge":%q,
+				"required_file_sha256":%q,
+				"files_inspected":[%q]
+			}
+		}`, receipt.Challenge, sha256Hex(string(required)), receipt.RequiredFile)
+		return nil
+	}
+	artifact, err := Run(Options{
+		Target:   target,
+		Profile:  clawHubProfileID,
+		Scanners: []string{"clawscan-static"},
+		Judge: &JudgeOptions{
+			Command: "judge --output {{ output }}",
+		},
+	}, RunContext{
+		Env:           map[string]string{},
+		ScannerRunner: staticScannerRunner{results: map[string]ScannerResult{"clawscan-static": {Status: "completed", Raw: json.RawMessage(`{}`)}}},
+		CommandRunner: commandRunner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Judge == nil || artifact.Judge.Status != "completed" {
+		t.Fatalf("judge = %#v", artifact.Judge)
 	}
 }
 


### PR DESCRIPTION
## Summary
- use ClawScan's outer Docker runtime as the Codex sandbox boundary while retaining `read-only` when Docker sandboxing is disabled
- require the ClawHub judge to read a random workspace challenge and return the verified SHA-256 of a required artifact file
- mark the judge failed when the inspection receipt is missing, mismatched, or does not include the required artifact file

## Root cause
Codex's nested `read-only` sandbox could not inspect workspace files from inside the ClawScan Docker runtime, but still returned a low-confidence verdict. The same input inspected successfully without the nested sandbox.

## Validation
- `go test ./...`
- `go vet ./...`
- exact replay of `enterprise-file-writer@1.2.3` with production scanner evidence: completed with an inspection receipt for `artifact/SKILL.md` matching SHA-256 `f670d451c14ea05557fccf549ea738f8b073d224d4955f58f5340a59a85ca802`
