### PR TITLE
fix: tolerate extra artifact inspection paths

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1298,10 +1298,11 @@ func validateArtifactInspectionReceipt(result map[string]any, expected artifactI
 	requiredFileInspected := false
 	for _, value := range files {
 		file, ok := value.(string)
-		if !ok || !strings.HasPrefix(filepath.ToSlash(filepath.Clean(file)), "artifact/") {
-			return fmt.Errorf("Judge artifact inspection reported invalid file path %q.", value)
+		if !ok {
+			continue
 		}
-		if filepath.ToSlash(filepath.Clean(file)) == expected.RequiredFile {
+		clean := filepath.ToSlash(filepath.Clean(file))
+		if clean == expected.RequiredFile {
 			requiredFileInspected = true
 		}
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2933,6 +2933,54 @@ func TestRunClawHubJudgeAcceptsVerifiedArtifactInspectionReceipt(t *testing.T) {
 	}
 }
 
+func TestValidateArtifactInspectionReceiptIgnoresUnverifiableExtraPaths(t *testing.T) {
+	expected := artifactInspectionChallenge{
+		Challenge:      "challenge",
+		RequiredFile:   "artifact/SKILL.md",
+		RequiredSHA256: strings.Repeat("a", 64),
+	}
+	result := map[string]any{
+		"artifact_inspection": map[string]any{
+			"status":               "completed",
+			"challenge":            expected.Challenge,
+			"required_file_sha256": expected.RequiredSHA256,
+			"files_inspected": []any{
+				"artifact/",
+				"artifact/../artifact-inspection.json",
+				expected.RequiredFile,
+			},
+		},
+	}
+
+	if err := validateArtifactInspectionReceipt(result, expected); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateArtifactInspectionReceiptStillRequiresChallengedFile(t *testing.T) {
+	expected := artifactInspectionChallenge{
+		Challenge:      "challenge",
+		RequiredFile:   "artifact/SKILL.md",
+		RequiredSHA256: strings.Repeat("a", 64),
+	}
+	result := map[string]any{
+		"artifact_inspection": map[string]any{
+			"status":               "completed",
+			"challenge":            expected.Challenge,
+			"required_file_sha256": expected.RequiredSHA256,
+			"files_inspected": []any{
+				"artifact/",
+				"artifact/../artifact-inspection.json",
+			},
+		},
+	}
+
+	err := validateArtifactInspectionReceipt(result, expected)
+	if err == nil || !strings.Contains(err.Error(), "did not include required file") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestRunLoadsExplicitContextJSON(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "skill")


### PR DESCRIPTION
## Summary
- tolerate unverifiable extra `files_inspected` entries in artifact inspection receipts
- continue requiring the exact challenged artifact file, challenge, and SHA-256
- add regressions for the observed `artifact/` and traversal-shaped extra claims

## Validation
- `go test ./...`
- `go vet ./...`
- `node --test npm/clawscan/test/*.test.mjs`
- `node --test scripts/build-npm-package.test.mjs`
- autoreview clean
