### PR TITLE
feat(profiles)!: require explicit config; stop auto-discovering .clawscan.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ ClawScan turns that approach into a repeatable CLI. It includes a built-in `claw
 | --- | --- |
 | `clawscan <target> --scanner <id>` | Run one or more scanners against an explicit skill or OpenClaw plugin target. Omit `<target>` to scan child skill directories under `./skills`; plugins are never auto-discovered. |
 | `clawscan scanners [list\|<scanner-id>]` | Discover supported scanner IDs, required env vars, upstream links, descriptions, and install guidance. |
-| `clawscan profiles [-v]` | Inspect built-in plus nearest project-local profiles; `-v` prints the resolved profile catalog as YAML. |
+| `clawscan profiles [-v]` | Inspect built-in profiles; `-v` prints the catalog as YAML. |
 | `clawscan benchmark [list\|<benchmark-id>]` | Discover or run supported benchmarks through a selected scanner/profile/judge setup. |
 | `clawscan install <scanner-id> [...]` | Install or verify local scanner dependencies where ClawScan has registry-backed install plans. |
 
@@ -173,8 +173,7 @@ The same profile accepts an explicit OpenClaw plugin directory (or its
 `openclaw.plugin.json` manifest), runs both scanners, and renders the
 bundled judge prompt with `packageRelease` target context.
 
-Inspect the resolved profile catalog, including the nearest project
-`.clawscan.yml` / `.clawscan.yaml` when present:
+Inspect the built-in profile catalog:
 
 ```bash
 clawscan profiles

--- a/cmd/clawscan/main.go
+++ b/cmd/clawscan/main.go
@@ -575,7 +575,7 @@ Usage:
 Core flags:
   --profile <name>            Profile to run. Use --profile clawhub for ClawHub parity.
   --config <path>             Load profiles from a specific .clawscan.yml file; omit --profile to run them all.
-  --discover-config           Find and load the nearest .clawscan.yml/.clawscan.yaml in the current directory or a parent.
+  --discover-config           Find and load the nearest .clawscan.yml/.clawscan.yaml in the current directory or a parent. Requires --profile.
   --scanner <id>              Scanner to run. Repeat for multiple scanners.
   --scanner-result <id=path>  Use a JSON fixture instead of running that scanner.
   --context <path>            Load profile runtime context from a JSON file.

--- a/cmd/clawscan/main.go
+++ b/cmd/clawscan/main.go
@@ -61,7 +61,6 @@ func run(args []string, environ []string) error {
 	if err != nil {
 		return err
 	}
-	printIgnoredConfigNotice(os.Stderr, resolved.IgnoredConfig)
 	if resolved.AllProfiles {
 		return runAllProfiles(resolved, environ, cwd)
 	}
@@ -125,7 +124,6 @@ func runBenchmarkCommand(args []string, environ []string) error {
 	if err != nil {
 		return err
 	}
-	printIgnoredConfigNotice(os.Stderr, resolved.IgnoredConfig)
 	if resolved.AllProfiles {
 		return errors.New("clawscan benchmark does not support --config without --profile")
 	}
@@ -153,13 +151,6 @@ func runBenchmarkCommand(args []string, environ []string) error {
 	}
 	printBenchmarkSummary(os.Stdout, artifact, "")
 	return nil
-}
-
-func printIgnoredConfigNotice(w io.Writer, configPath string) {
-	if configPath == "" {
-		return
-	}
-	fmt.Fprintf(w, "warning: discovered %s at %s but not loading it; use --config %s or --discover-config to load discovered config\n", filepath.Base(configPath), configPath, configPath)
 }
 
 func runAllProfiles(resolved profiles.ResolvedRunSet, environ []string, cwd string) error {
@@ -244,7 +235,7 @@ func runProfiles(args []string) error {
 	if err != nil {
 		return err
 	}
-	catalog, err := profiles.InspectProfiles(cwd)
+	catalog, err := profiles.InspectProfiles()
 	if err != nil {
 		return err
 	}
@@ -575,7 +566,7 @@ Usage:
 Core flags:
   --profile <name>            Profile to run. Use --profile clawhub for ClawHub parity.
   --config <path>             Load profiles from a specific .clawscan.yml file; omit --profile to run them all.
-  --discover-config           Find and load the nearest .clawscan.yml/.clawscan.yaml in the current directory or a parent. Requires --profile.
+  --discover-config           Find and load the nearest .clawscan.yml/.clawscan.yaml in the current directory or a parent. Requires --profile. Off by default: config files can define scanners that run arbitrary commands, so ClawScan never loads config it was not explicitly told to trust.
   --scanner <id>              Scanner to run. Repeat for multiple scanners.
   --scanner-result <id=path>  Use a JSON fixture instead of running that scanner.
   --context <path>            Load profile runtime context from a JSON file.
@@ -606,7 +597,7 @@ Catalog commands:
   clawscan scanners           List supported scanners with required env vars.
   clawscan scanners list      Alias for clawscan scanners.
   clawscan scanners <id>      Show scanner repository, description, env vars, and install guidance.
-  clawscan profiles           List built-in plus nearest project .clawscan.yml/.clawscan.yaml profiles.
+  clawscan profiles           List built-in profiles.
   clawscan profiles -v        Print the resolved profile catalog as pasteable YAML.
   clawscan benchmark list     List supported benchmarks with source datasets and splits.
 

--- a/cmd/clawscan/main.go
+++ b/cmd/clawscan/main.go
@@ -61,6 +61,7 @@ func run(args []string, environ []string) error {
 	if err != nil {
 		return err
 	}
+	printIgnoredConfigNotice(os.Stderr, resolved.IgnoredConfig)
 	if resolved.AllProfiles {
 		return runAllProfiles(resolved, environ, cwd)
 	}
@@ -124,6 +125,7 @@ func runBenchmarkCommand(args []string, environ []string) error {
 	if err != nil {
 		return err
 	}
+	printIgnoredConfigNotice(os.Stderr, resolved.IgnoredConfig)
 	if resolved.AllProfiles {
 		return errors.New("clawscan benchmark does not support --config without --profile")
 	}
@@ -151,6 +153,13 @@ func runBenchmarkCommand(args []string, environ []string) error {
 	}
 	printBenchmarkSummary(os.Stdout, artifact, "")
 	return nil
+}
+
+func printIgnoredConfigNotice(w io.Writer, configPath string) {
+	if configPath == "" {
+		return
+	}
+	fmt.Fprintf(w, "warning: discovered %s at %s but not loading it; use --config %s or --discover-config to load discovered config\n", filepath.Base(configPath), configPath, configPath)
 }
 
 func runAllProfiles(resolved profiles.ResolvedRunSet, environ []string, cwd string) error {
@@ -566,6 +575,7 @@ Usage:
 Core flags:
   --profile <name>            Profile to run. Use --profile clawhub for ClawHub parity.
   --config <path>             Load profiles from a specific .clawscan.yml file; omit --profile to run them all.
+  --discover-config           Find and load the nearest .clawscan.yml/.clawscan.yaml in the current directory or a parent.
   --scanner <id>              Scanner to run. Repeat for multiple scanners.
   --scanner-result <id=path>  Use a JSON fixture instead of running that scanner.
   --context <path>            Load profile runtime context from a JSON file.

--- a/cmd/clawscan/main_test.go
+++ b/cmd/clawscan/main_test.go
@@ -32,6 +32,7 @@ func TestRunCommandPrintsHelp(t *testing.T) {
 		"Install scanner dependencies without running scans.",
 		"--profile <name>",
 		"--config <path>",
+		"--discover-config",
 		"Benchmark command flags:",
 		"--split <name>",
 		"--ids <path-or-url>",
@@ -675,7 +676,7 @@ profiles:
 	t.Chdir(dir)
 
 	stdout := captureStdout(t, func() {
-		if err := run([]string{target, "--profile", "local"}, []string{}); err != nil {
+		if err := run([]string{target, "--profile", "local", "--discover-config"}, []string{}); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -695,7 +696,150 @@ profiles:
 	}
 }
 
-func TestRunCommandConfigWithoutProfileRunsEveryConfigProfile(t *testing.T) {
+func TestRunDefaultModeIgnoresConfigAndPrintsNotice(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "skill")
+	writeSkill(t, target, "# Ignored config\n")
+	config := filepath.Join(dir, ".clawscan.yml")
+	writeFile(t, config, "version: [\n")
+	t.Chdir(dir)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := run([]string{target, "--scanner", "clawscan-static", "--json"}, []string{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	var artifact struct {
+		ConfigSource string `json:"configSource"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &artifact); err != nil {
+		t.Fatalf("stdout is not artifact JSON: %v\n%s", err, stdout)
+	}
+	if artifact.ConfigSource != "flags-only" {
+		t.Fatalf("config source = %q", artifact.ConfigSource)
+	}
+	want := "warning: discovered .clawscan.yml at " + config + " but not loading it; use --config " + config + " or --discover-config to load discovered config\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	if strings.Contains(stdout, "warning: discovered") {
+		t.Fatalf("notice leaked to stdout: %s", stdout)
+	}
+}
+
+func TestRunDefaultModeIgnoresParentConfigAndPrintsNotice(t *testing.T) {
+	parent := t.TempDir()
+	config := filepath.Join(parent, ".clawscan.yml")
+	writeFile(t, config, "version: [\n")
+	child := filepath.Join(parent, "child")
+	target := filepath.Join(child, "skill")
+	writeSkill(t, target, "# Parent ignored config\n")
+	t.Chdir(child)
+
+	_, stderr := captureOutput(t, func() {
+		if err := run([]string{target, "--scanner", "clawscan-static", "--json"}, []string{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(stderr, config) || !strings.Contains(stderr, "--discover-config") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestRunWithDiscoverConfigLoadsConfig_NoNotice(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "skill")
+	writeSkill(t, target, "# Discovered config\n")
+	config := filepath.Join(dir, ".clawscan.yml")
+	writeFile(t, config, `version: 1
+profiles:
+  custom:
+    scanners:
+      - clawscan-static
+`)
+	t.Chdir(dir)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := run([]string{target, "--profile", "custom", "--discover-config", "--json"}, []string{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	var artifact struct {
+		ConfigSource string `json:"configSource"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &artifact); err != nil {
+		t.Fatal(err)
+	}
+	if artifact.ConfigSource != config {
+		t.Fatalf("config source = %q, want %q", artifact.ConfigSource, config)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestRunWithExplicitConfigLoadsConfig_NoNotice(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "skill")
+	writeSkill(t, target, "# Explicit config\n")
+	writeFile(t, filepath.Join(dir, ".clawscan.yml"), "version: [\n")
+	explicit := filepath.Join(dir, "explicit.yml")
+	writeFile(t, explicit, `version: 1
+profiles:
+  p:
+    scanners:
+      - clawscan-static
+`)
+	t.Chdir(dir)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := run([]string{target, "--config", explicit, "--profile", "p", "--json"}, []string{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	var artifact struct {
+		ConfigSource string `json:"configSource"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &artifact); err != nil {
+		t.Fatal(err)
+	}
+	if artifact.ConfigSource != explicit {
+		t.Fatalf("config source = %q, want %q", artifact.ConfigSource, explicit)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestRunJSONFlagDoesNotIncludeNoticeInStdout(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "skill")
+	writeSkill(t, target, "# JSON notice separation\n")
+	writeFile(t, filepath.Join(dir, ".clawscan.yml"), "version: 1\nprofiles: {}\n")
+	t.Chdir(dir)
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := run([]string{target, "--scanner", "clawscan-static", "--json"}, []string{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !json.Valid([]byte(stdout)) {
+		t.Fatalf("stdout is not valid JSON: %s", stdout)
+	}
+	if strings.Contains(stdout, "warning: discovered") {
+		t.Fatalf("notice leaked to stdout: %s", stdout)
+	}
+	if !strings.Contains(stderr, "warning: discovered") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+}
+
+func TestBatchArtifactRuns_EachHasConfigSource(t *testing.T) {
 	dir := t.TempDir()
 	writeSkill(t, filepath.Join(dir, "skills", "foo"), "# Foo\n")
 	writeSkill(t, filepath.Join(dir, "skills", "bar"), "# Bar\n")
@@ -720,8 +864,9 @@ profiles:
 	var artifact struct {
 		SchemaVersion string `json:"schemaVersion"`
 		Runs          []struct {
-			Profile  string                 `json:"profile"`
-			Scanners map[string]interface{} `json:"scanners"`
+			Profile      string                 `json:"profile"`
+			ConfigSource string                 `json:"configSource"`
+			Scanners     map[string]interface{} `json:"scanners"`
 		} `json:"runs"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &artifact); err != nil {
@@ -737,6 +882,9 @@ profiles:
 		t.Fatalf("profiles = %q", got)
 	}
 	for _, run := range artifact.Runs {
+		if run.ConfigSource != config {
+			t.Fatalf("config source = %q, want %q", run.ConfigSource, config)
+		}
 		if _, ok := run.Scanners["clawscan-static"]; !ok {
 			t.Fatalf("missing clawscan-static scanner for %s: %#v", run.Profile, run.Scanners)
 		}
@@ -863,4 +1011,51 @@ func captureStdout(t *testing.T, fn func()) string {
 	}
 	os.Stdout = original
 	return string(out)
+}
+
+func captureOutput(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+	stdoutRead, stdoutWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderrRead, stderrWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = stdoutWrite
+	os.Stderr = stderrWrite
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+	})
+
+	fn()
+
+	if err := stdoutWrite.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := stderrWrite.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := io.ReadAll(stdoutRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderr, err := io.ReadAll(stderrRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stdoutRead.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := stderrRead.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = originalStdout
+	os.Stderr = originalStderr
+	return string(stdout), string(stderr)
 }

--- a/cmd/clawscan/main_test.go
+++ b/cmd/clawscan/main_test.go
@@ -713,13 +713,16 @@ func TestRunDefaultModeIgnoresConfigWithoutNotice(t *testing.T) {
 	})
 
 	var artifact struct {
-		ConfigSource string `json:"configSource"`
+		ConfigSource *string `json:"configSource"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &artifact); err != nil {
 		t.Fatalf("stdout is not artifact JSON: %v\n%s", err, stdout)
 	}
-	if artifact.ConfigSource != "flags-only" {
-		t.Fatalf("config source = %q", artifact.ConfigSource)
+	if artifact.ConfigSource != nil {
+		t.Fatalf("config source = %q, want nil", *artifact.ConfigSource)
+	}
+	if !strings.Contains(stdout, `"configSource": null`) {
+		t.Fatalf("stdout lacks explicit null config source: %s", stdout)
 	}
 	if stderr != "" {
 		t.Fatalf("stderr = %q, want empty", stderr)
@@ -746,13 +749,16 @@ profiles:
 	})
 
 	var artifact struct {
-		ConfigSource string `json:"configSource"`
+		ConfigSource *string `json:"configSource"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &artifact); err != nil {
 		t.Fatal(err)
 	}
-	if artifact.ConfigSource != config {
-		t.Fatalf("config source = %q, want %q", artifact.ConfigSource, config)
+	if artifact.ConfigSource == nil {
+		t.Fatalf("config source = nil, want %q", config)
+	}
+	if *artifact.ConfigSource != config {
+		t.Fatalf("config source = %q, want %q", *artifact.ConfigSource, config)
 	}
 	if stderr != "" {
 		t.Fatalf("stderr = %q", stderr)
@@ -780,13 +786,16 @@ profiles:
 	})
 
 	var artifact struct {
-		ConfigSource string `json:"configSource"`
+		ConfigSource *string `json:"configSource"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &artifact); err != nil {
 		t.Fatal(err)
 	}
-	if artifact.ConfigSource != explicit {
-		t.Fatalf("config source = %q, want %q", artifact.ConfigSource, explicit)
+	if artifact.ConfigSource == nil {
+		t.Fatalf("config source = nil, want %q", explicit)
+	}
+	if *artifact.ConfigSource != explicit {
+		t.Fatalf("config source = %q, want %q", *artifact.ConfigSource, explicit)
 	}
 	if stderr != "" {
 		t.Fatalf("stderr = %q", stderr)
@@ -819,7 +828,7 @@ profiles:
 		SchemaVersion string `json:"schemaVersion"`
 		Runs          []struct {
 			Profile      string                 `json:"profile"`
-			ConfigSource string                 `json:"configSource"`
+			ConfigSource *string                `json:"configSource"`
 			Scanners     map[string]interface{} `json:"scanners"`
 		} `json:"runs"`
 	}
@@ -836,8 +845,11 @@ profiles:
 		t.Fatalf("profiles = %q", got)
 	}
 	for _, run := range artifact.Runs {
-		if run.ConfigSource != config {
-			t.Fatalf("config source = %q, want %q", run.ConfigSource, config)
+		if run.ConfigSource == nil {
+			t.Fatalf("config source = nil, want %q", config)
+		}
+		if *run.ConfigSource != config {
+			t.Fatalf("config source = %q, want %q", *run.ConfigSource, config)
 		}
 		if _, ok := run.Scanners["clawscan-static"]; !ok {
 			t.Fatalf("missing clawscan-static scanner for %s: %#v", run.Profile, run.Scanners)

--- a/cmd/clawscan/main_test.go
+++ b/cmd/clawscan/main_test.go
@@ -151,7 +151,7 @@ func TestRunCommandScannerDetailPrintsHumanReadableInfo(t *testing.T) {
 	}
 }
 
-func TestRunCommandProfilesPrintsMergedDiscoveredProfiles(t *testing.T) {
+func TestRunCommandProfilesPrintsBuiltInProfilesOnly(t *testing.T) {
 	dir := t.TempDir()
 	removedProfile := "skills" + "-sh"
 	writeFile(t, filepath.Join(dir, ".clawscan.yml"), `version: 1
@@ -178,12 +178,10 @@ profiles:
 		"Source",
 		"Scanners",
 		"clawhub",
-		".clawscan.yml",
-		"clawscan-static",
+		"built-in",
+		"skillspector, clawscan-static",
 		"clawhub-aig",
 		"skillspector, aig",
-		"local-review",
-		"snyk",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("profiles output missing %q:\n%s", want, stdout)
@@ -191,6 +189,9 @@ profiles:
 	}
 	if strings.Contains(stdout, removedProfile) {
 		t.Fatalf("profiles output should not include removed profile %q:\n%s", removedProfile, stdout)
+	}
+	if strings.Contains(stdout, "local-review") {
+		t.Fatalf("profiles output should not include project profile:\n%s", stdout)
 	}
 }
 
@@ -217,10 +218,8 @@ profiles:
 		"profiles:",
 		"clawhub:",
 		"clawhub-aig:",
-		"local-review:",
-		"- clawscan-static",
+		"- skillspector",
 		"- aig",
-		"json: true",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("verbose profiles output missing %q:\n%s", want, stdout)
@@ -228,6 +227,9 @@ profiles:
 	}
 	if strings.Contains(stdout, removedProfile+":") {
 		t.Fatalf("verbose profiles output should not include removed profile %q:\n%s", removedProfile, stdout)
+	}
+	if strings.Contains(stdout, "local-review:") {
+		t.Fatalf("verbose profiles output should not include project profile:\n%s", stdout)
 	}
 }
 
@@ -696,7 +698,7 @@ profiles:
 	}
 }
 
-func TestRunDefaultModeIgnoresConfigAndPrintsNotice(t *testing.T) {
+func TestRunDefaultModeIgnoresConfigWithoutNotice(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "skill")
 	writeSkill(t, target, "# Ignored config\n")
@@ -719,32 +721,8 @@ func TestRunDefaultModeIgnoresConfigAndPrintsNotice(t *testing.T) {
 	if artifact.ConfigSource != "flags-only" {
 		t.Fatalf("config source = %q", artifact.ConfigSource)
 	}
-	want := "warning: discovered .clawscan.yml at " + config + " but not loading it; use --config " + config + " or --discover-config to load discovered config\n"
-	if stderr != want {
-		t.Fatalf("stderr = %q, want %q", stderr, want)
-	}
-	if strings.Contains(stdout, "warning: discovered") {
-		t.Fatalf("notice leaked to stdout: %s", stdout)
-	}
-}
-
-func TestRunDefaultModeIgnoresParentConfigAndPrintsNotice(t *testing.T) {
-	parent := t.TempDir()
-	config := filepath.Join(parent, ".clawscan.yml")
-	writeFile(t, config, "version: [\n")
-	child := filepath.Join(parent, "child")
-	target := filepath.Join(child, "skill")
-	writeSkill(t, target, "# Parent ignored config\n")
-	t.Chdir(child)
-
-	_, stderr := captureOutput(t, func() {
-		if err := run([]string{target, "--scanner", "clawscan-static", "--json"}, []string{}); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	if !strings.Contains(stderr, config) || !strings.Contains(stderr, "--discover-config") {
-		t.Fatalf("stderr = %q", stderr)
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
 	}
 }
 
@@ -811,30 +789,6 @@ profiles:
 		t.Fatalf("config source = %q, want %q", artifact.ConfigSource, explicit)
 	}
 	if stderr != "" {
-		t.Fatalf("stderr = %q", stderr)
-	}
-}
-
-func TestRunJSONFlagDoesNotIncludeNoticeInStdout(t *testing.T) {
-	dir := t.TempDir()
-	target := filepath.Join(dir, "skill")
-	writeSkill(t, target, "# JSON notice separation\n")
-	writeFile(t, filepath.Join(dir, ".clawscan.yml"), "version: 1\nprofiles: {}\n")
-	t.Chdir(dir)
-
-	stdout, stderr := captureOutput(t, func() {
-		if err := run([]string{target, "--scanner", "clawscan-static", "--json"}, []string{}); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	if !json.Valid([]byte(stdout)) {
-		t.Fatalf("stdout is not valid JSON: %s", stdout)
-	}
-	if strings.Contains(stdout, "warning: discovered") {
-		t.Fatalf("notice leaked to stdout: %s", stdout)
-	}
-	if !strings.Contains(stderr, "warning: discovered") {
 		t.Fatalf("stderr = %q", stderr)
 	}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,6 @@ ClawScan turns that approach into a repeatable CLI. It includes a built-in `claw
 | --- | --- |
 | `clawscan <target> --scanner <id>` | Run one or more scanners against an explicit target. Omit `<target>` to scan child skill directories under `./skills`. |
 | `clawscan scanners [list\|<scanner-id>]` | Discover supported scanner IDs, required env vars, upstream links, descriptions, and install guidance. |
-| `clawscan profiles [-v]` | Inspect built-in plus nearest project-local profiles; `-v` prints the resolved profile catalog as YAML. |
+| `clawscan profiles [-v]` | Inspect built-in profiles; `-v` prints the catalog as YAML. |
 | `clawscan benchmark [list\|<benchmark-id>]` | Discover or run supported benchmarks through a selected scanner/profile/judge setup. |
 | `clawscan install <scanner-id> [...]` | Install or verify local scanner dependencies where ClawScan has registry-backed install plans. |

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -24,7 +24,10 @@ To load a discovered config file, use one of these flags:
 - `--config <path>` - Explicitly specify a config file path
 - `--discover-config` - Search upward from the current directory and load the nearest `.clawscan.yml` or `.clawscan.yaml`
 
-Mixing `--config` and `--discover-config` is an error.
+Mixing `--config` and `--discover-config` is an error. `--discover-config`
+also requires `--profile`: without a profile the run would record the
+discovered file as its config source while applying none of its settings.
+Use `--config <path>` without `--profile` to run every profile in a config.
 
 ```bash
 clawscan ./my-skill --config ./security/clawscan.yml --profile review

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -15,9 +15,14 @@ bundled judge prompt with `packageRelease` target context.
 ## Config discovery
 
 By default, ClawScan does not auto-discover `.clawscan.yml` or `.clawscan.yaml`
-files from the current directory or parent directories. If your run detects a
-config file that could have been loaded, ClawScan prints a notice to stderr
-suggesting you use `--config <path>` or `--discover-config`.
+files from the current directory or parent directories.
+
+ClawScan never loads a config file it was not explicitly pointed at. A
+`.clawscan.yml` can define user-defined scanners whose commands execute with
+your credentials in the environment, so silently loading one from the current
+directory or a parent (for example, from inside a repository you are scanning)
+would let an untrusted target execute commands. Pass `--config <path>` or opt in
+with `--discover-config`.
 
 To load a discovered config file, use one of these flags:
 
@@ -35,14 +40,11 @@ clawscan ./my-skill --profile review --discover-config
 ```
 
 Without either flag, ClawScan uses built-in profiles and CLI flags only. The
-warning is a single stderr line and never changes JSON stdout. The
-`clawscan profiles` catalog command still includes the nearest discovered
-project config.
+`clawscan profiles` catalog command lists built-in profiles only.
 
 ## Inspect available profiles
 
-Inspect the resolved profile catalog, including the nearest project
-`.clawscan.yml` / `.clawscan.yaml` when present:
+Inspect the built-in profile catalog:
 
 ```bash
 clawscan profiles

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -12,6 +12,32 @@ The same profile accepts an explicit OpenClaw plugin directory (or its
 `openclaw.plugin.json` manifest), runs both scanners, and renders the
 bundled judge prompt with `packageRelease` target context.
 
+## Config discovery
+
+By default, ClawScan does not auto-discover `.clawscan.yml` or `.clawscan.yaml`
+files from the current directory or parent directories. If your run detects a
+config file that could have been loaded, ClawScan prints a notice to stderr
+suggesting you use `--config <path>` or `--discover-config`.
+
+To load a discovered config file, use one of these flags:
+
+- `--config <path>` - Explicitly specify a config file path
+- `--discover-config` - Search upward from the current directory and load the nearest `.clawscan.yml` or `.clawscan.yaml`
+
+Mixing `--config` and `--discover-config` is an error.
+
+```bash
+clawscan ./my-skill --config ./security/clawscan.yml --profile review
+clawscan ./my-skill --profile review --discover-config
+```
+
+Without either flag, ClawScan uses built-in profiles and CLI flags only. The
+warning is a single stderr line and never changes JSON stdout. The
+`clawscan profiles` catalog command still includes the nearest discovered
+project config.
+
+## Inspect available profiles
+
 Inspect the resolved profile catalog, including the nearest project
 `.clawscan.yml` / `.clawscan.yaml` when present:
 

--- a/internal/profiles/registry.go
+++ b/internal/profiles/registry.go
@@ -53,11 +53,8 @@ func ProfileIDs() []string {
 	return DefaultProfileRegistry().IDs()
 }
 
-func InspectProfiles(cwd string) (ProfileCatalog, error) {
-	registry, _, err := loadConfigs(cwd, "", true)
-	if err != nil {
-		return ProfileCatalog{}, err
-	}
+func InspectProfiles() (ProfileCatalog, error) {
+	registry := DefaultProfileRegistry()
 	catalog := ProfileCatalog{profiles: map[string]ProfileInfo{}}
 	for _, id := range registry.IDs() {
 		resolved, _ := registry.Profile(id)

--- a/internal/profiles/registry.go
+++ b/internal/profiles/registry.go
@@ -54,7 +54,7 @@ func ProfileIDs() []string {
 }
 
 func InspectProfiles(cwd string) (ProfileCatalog, error) {
-	registry, err := loadConfigs(cwd, "")
+	registry, _, err := loadConfigs(cwd, "", true)
 	if err != nil {
 		return ProfileCatalog{}, err
 	}

--- a/internal/profiles/registry_test.go
+++ b/internal/profiles/registry_test.go
@@ -1,8 +1,6 @@
 package profiles
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -80,27 +78,12 @@ func TestProfileRegistryRejectsUnknownScannerReferences(t *testing.T) {
 	}
 }
 
-func TestInspectProfilesDiscoversNearestConfigAndShadowsBuiltIns(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, ".clawscan.yml"), `version: 1
-profiles:
-  clawhub:
-    scanners:
-      - clawscan-static
-  local:
-    scanners:
-      - socket
-`)
-	nested := filepath.Join(dir, "nested")
-	if err := os.Mkdir(nested, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	catalog, err := InspectProfiles(nested)
+func TestInspectProfilesReturnsBuiltIns(t *testing.T) {
+	catalog, err := InspectProfiles()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := strings.Join(catalog.IDs(), ","); got != "clawhub,clawhub-aig,local" {
+	if got := strings.Join(catalog.IDs(), ","); got != "clawhub,clawhub-aig" {
 		t.Fatalf("profile ids = %q", got)
 	}
 
@@ -108,10 +91,10 @@ profiles:
 	if !ok {
 		t.Fatal("missing clawhub profile")
 	}
-	if got := strings.Join(clawhub.Profile.Scanners, ","); got != "clawscan-static" {
+	if got := strings.Join(clawhub.Profile.Scanners, ","); got != "skillspector,clawscan-static" {
 		t.Fatalf("clawhub scanners = %q", got)
 	}
-	if !strings.HasSuffix(clawhub.Source, ".clawscan.yml") {
+	if clawhub.Source != "built-in" {
 		t.Fatalf("clawhub source = %q", clawhub.Source)
 	}
 

--- a/internal/profiles/resolver.go
+++ b/internal/profiles/resolver.go
@@ -92,11 +92,10 @@ type cliIntent struct {
 var judgePathPlaceholderPattern = regexp.MustCompile(`\{\{\s*(prompt|output_schema):([^}]+)\}\}`)
 
 type ResolvedRunSet struct {
-	Options       []runner.Options
-	OutputPath    string
-	JSON          bool
-	AllProfiles   bool
-	IgnoredConfig string
+	Options     []runner.Options
+	OutputPath  string
+	JSON        bool
+	AllProfiles bool
 }
 
 func ResolveArgs(args []string, cwd string) (runner.Options, error) {
@@ -171,15 +170,7 @@ func resolveRunSetIntent(intent cliIntent, cwd string) (ResolvedRunSet, error) {
 			var ok bool
 			selected, ok = registry.Profile(profileName)
 			if !ok {
-				err := unknownProfileError(profileName, registry.IDs())
-				// The profile may live in a discovered-but-unloaded config;
-				// surface the migration hint here or the user never sees it.
-				if intent.configPath == "" && !intent.discoverConfig {
-					if ignored, findErr := findIgnoredConfig(cwd); findErr == nil && ignored != "" {
-						err = fmt.Errorf("%w (found %s but did not load it; pass --config %s or --discover-config)", err, ignored, ignored)
-					}
-				}
-				return ResolvedRunSet{}, err
+				return ResolvedRunSet{}, unknownProfileError(profileName, registry.IDs())
 			}
 			// selected.source is authoritative: a profile served from
 			// embedded YAML is "built-in" even when an unrelated project
@@ -201,12 +192,6 @@ func resolveRunSetIntent(intent cliIntent, cwd string) (ResolvedRunSet, error) {
 	opts.Profile = profileName
 	opts.ConfigSource = configSource
 	opts.DiscoverConfig = intent.discoverConfig
-	if intent.configPath == "" && !intent.discoverConfig {
-		opts.IgnoredConfig, err = findIgnoredConfig(cwd)
-		if err != nil {
-			return ResolvedRunSet{}, err
-		}
-	}
 	if opts.Judge != nil {
 		opts.Judge.Files = files
 	}
@@ -217,10 +202,9 @@ func resolveRunSetIntent(intent cliIntent, cwd string) (ResolvedRunSet, error) {
 		}
 	}
 	return ResolvedRunSet{
-		Options:       []runner.Options{opts},
-		OutputPath:    opts.OutputPath,
-		JSON:          opts.JSON,
-		IgnoredConfig: opts.IgnoredConfig,
+		Options:    []runner.Options{opts},
+		OutputPath: opts.OutputPath,
+		JSON:       opts.JSON,
 	}, nil
 }
 
@@ -441,26 +425,6 @@ func discoverConfig(cwd string) (string, error) {
 		}
 		if yamlExists {
 			return yamlPath, nil
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			return "", nil
-		}
-		current = parent
-	}
-}
-
-func findIgnoredConfig(cwd string) (string, error) {
-	current, err := filepath.Abs(cwd)
-	if err != nil {
-		return "", err
-	}
-	for {
-		for _, name := range []string{".clawscan.yml", ".clawscan.yaml"} {
-			path := filepath.Join(current, name)
-			if fileExists(path) {
-				return path, nil
-			}
 		}
 		parent := filepath.Dir(current)
 		if parent == current {

--- a/internal/profiles/resolver.go
+++ b/internal/profiles/resolver.go
@@ -61,6 +61,7 @@ type cliIntent struct {
 	profile              string
 	profileSet           bool
 	configPath           string
+	discoverConfig       bool
 	contextPath          string
 	scanners             []string
 	scannerResultPaths   map[string]string
@@ -91,10 +92,11 @@ type cliIntent struct {
 var judgePathPlaceholderPattern = regexp.MustCompile(`\{\{\s*(prompt|output_schema):([^}]+)\}\}`)
 
 type ResolvedRunSet struct {
-	Options     []runner.Options
-	OutputPath  string
-	JSON        bool
-	AllProfiles bool
+	Options       []runner.Options
+	OutputPath    string
+	JSON          bool
+	AllProfiles   bool
+	IgnoredConfig string
 }
 
 func ResolveArgs(args []string, cwd string) (runner.Options, error) {
@@ -145,17 +147,26 @@ func resolveRunSetIntent(intent cliIntent, cwd string) (ResolvedRunSet, error) {
 	}
 
 	profileName := ""
+	configSource := ""
+	if intent.configPath == "" && !intent.discoverConfig {
+		configSource = "flags-only"
+	}
 	selected := resolvedProfile{profile: Profile{}}
-	if intent.profileSet || intent.configPath != "" {
-		registry, err := loadConfigs(cwd, intent.configPath)
+	if intent.profileSet || intent.configPath != "" || intent.discoverConfig {
+		registry, loadedConfig, err := loadConfigs(cwd, intent.configPath, intent.discoverConfig)
 		if err != nil {
 			return ResolvedRunSet{}, err
 		}
-		profileName = intent.profile
-		var ok bool
-		selected, ok = registry.Profile(profileName)
-		if !ok {
-			return ResolvedRunSet{}, unknownProfileError(profileName, registry.IDs())
+		if loadedConfig != "" {
+			configSource = loadedConfig
+		}
+		if intent.profileSet {
+			profileName = intent.profile
+			var ok bool
+			selected, ok = registry.Profile(profileName)
+			if !ok {
+				return ResolvedRunSet{}, unknownProfileError(profileName, registry.IDs())
+			}
 		}
 	}
 
@@ -168,6 +179,14 @@ func resolveRunSetIntent(intent cliIntent, cwd string) (ResolvedRunSet, error) {
 		return ResolvedRunSet{}, err
 	}
 	opts.Profile = profileName
+	opts.ConfigSource = configSource
+	opts.DiscoverConfig = intent.discoverConfig
+	if intent.configPath == "" && !intent.discoverConfig {
+		opts.IgnoredConfig, err = findIgnoredConfig(cwd)
+		if err != nil {
+			return ResolvedRunSet{}, err
+		}
+	}
 	if opts.Judge != nil {
 		opts.Judge.Files = files
 	}
@@ -178,9 +197,10 @@ func resolveRunSetIntent(intent cliIntent, cwd string) (ResolvedRunSet, error) {
 		}
 	}
 	return ResolvedRunSet{
-		Options:    []runner.Options{opts},
-		OutputPath: opts.OutputPath,
-		JSON:       opts.JSON,
+		Options:       []runner.Options{opts},
+		OutputPath:    opts.OutputPath,
+		JSON:          opts.JSON,
+		IgnoredConfig: opts.IgnoredConfig,
 	}, nil
 }
 
@@ -192,7 +212,7 @@ func explicitRunSelectionError() error {
 	return errors.New("No scanner, profile, or config selected. Pass --scanner, --profile, or --config. Use `clawscan benchmark <benchmark-id>` for benchmark runs.")
 }
 
-func loadConfigs(cwd string, explicitConfig string) (ProfileRegistry, error) {
+func loadConfigs(cwd string, explicitConfig string, discover bool) (ProfileRegistry, string, error) {
 	registry := DefaultProfileRegistry()
 
 	var projectPath string
@@ -202,20 +222,25 @@ func loadConfigs(cwd string, explicitConfig string) (ProfileRegistry, error) {
 		if !filepath.IsAbs(projectPath) {
 			projectPath = filepath.Join(cwd, projectPath)
 		}
-	} else {
+		projectPath = filepath.Clean(projectPath)
+	} else if discover {
 		projectPath, err = discoverConfig(cwd)
 		if err != nil {
-			return ProfileRegistry{}, err
+			return ProfileRegistry{}, "", err
 		}
 	}
 	if projectPath == "" {
-		return registry, nil
+		return registry, "", nil
 	}
 	projectProfiles, err := loadProjectProfiles(projectPath)
 	if err != nil {
-		return ProfileRegistry{}, err
+		return ProfileRegistry{}, "", err
 	}
-	return registry.Merge(projectProfiles)
+	registry, err = registry.Merge(projectProfiles)
+	if err != nil {
+		return ProfileRegistry{}, "", err
+	}
+	return registry, projectPath, nil
 }
 
 func resolveAllConfigProfiles(intent cliIntent, cwd string) (ResolvedRunSet, error) {
@@ -258,6 +283,7 @@ func resolveAllConfigProfiles(intent cliIntent, cwd string) (ResolvedRunSet, err
 			return ResolvedRunSet{}, err
 		}
 		opts.Profile = profileName
+		opts.ConfigSource = filepath.Clean(projectPath)
 		opts.OutputPath = ""
 		opts.JSON = false
 		if opts.Judge != nil {
@@ -404,6 +430,26 @@ func discoverConfig(cwd string) (string, error) {
 	}
 }
 
+func findIgnoredConfig(cwd string) (string, error) {
+	current, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", err
+	}
+	for {
+		for _, name := range []string{".clawscan.yml", ".clawscan.yaml"} {
+			path := filepath.Join(current, name)
+			if fileExists(path) {
+				return path, nil
+			}
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", nil
+		}
+		current = parent
+	}
+}
+
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
@@ -434,6 +480,8 @@ func parseCLIIntent(args []string) (cliIntent, error) {
 			}
 			intent.configPath = value
 			i = next
+		case "--discover-config":
+			intent.discoverConfig = true
 		case "--context":
 			value, next, err := readValue(args, i, arg)
 			if err != nil {
@@ -551,6 +599,9 @@ func parseCLIIntent(args []string) (cliIntent, error) {
 		default:
 			return cliIntent{}, fmt.Errorf("Unknown argument: %s", arg)
 		}
+	}
+	if intent.configPath != "" && intent.discoverConfig {
+		return cliIntent{}, errors.New("--config and --discover-config are mutually exclusive")
 	}
 	return intent, nil
 }

--- a/internal/profiles/resolver.go
+++ b/internal/profiles/resolver.go
@@ -175,6 +175,12 @@ func resolveRunSetIntent(intent cliIntent, cwd string) (ResolvedRunSet, error) {
 				}
 				return ResolvedRunSet{}, err
 			}
+			// selected.source is authoritative: a profile served from
+			// embedded YAML is "built-in" even when an unrelated project
+			// config was loaded alongside it.
+			if selected.source == "built-in" {
+				configSource = "built-in"
+			}
 		}
 	}
 

--- a/internal/profiles/resolver.go
+++ b/internal/profiles/resolver.go
@@ -145,6 +145,12 @@ func resolveRunSetIntent(intent cliIntent, cwd string) (ResolvedRunSet, error) {
 	if intent.configPath != "" && !intent.profileSet {
 		return resolveAllConfigProfiles(intent, cwd)
 	}
+	// Discovery without a profile would record the discovered file as the
+	// run's ConfigSource while applying none of its settings — a provenance
+	// claim the run does not honor. Reject instead of misleading.
+	if intent.discoverConfig && !intent.profileSet {
+		return ResolvedRunSet{}, errors.New("--discover-config requires --profile; use --config <path> to run every profile in a config")
+	}
 
 	profileName := ""
 	configSource := ""

--- a/internal/profiles/resolver.go
+++ b/internal/profiles/resolver.go
@@ -165,7 +165,15 @@ func resolveRunSetIntent(intent cliIntent, cwd string) (ResolvedRunSet, error) {
 			var ok bool
 			selected, ok = registry.Profile(profileName)
 			if !ok {
-				return ResolvedRunSet{}, unknownProfileError(profileName, registry.IDs())
+				err := unknownProfileError(profileName, registry.IDs())
+				// The profile may live in a discovered-but-unloaded config;
+				// surface the migration hint here or the user never sees it.
+				if intent.configPath == "" && !intent.discoverConfig {
+					if ignored, findErr := findIgnoredConfig(cwd); findErr == nil && ignored != "" {
+						err = fmt.Errorf("%w (found %s but did not load it; pass --config %s or --discover-config)", err, ignored, ignored)
+					}
+				}
+				return ResolvedRunSet{}, err
 			}
 		}
 	}

--- a/internal/profiles/resolver.go
+++ b/internal/profiles/resolver.go
@@ -153,9 +153,6 @@ func resolveRunSetIntent(intent cliIntent, cwd string) (ResolvedRunSet, error) {
 
 	profileName := ""
 	configSource := ""
-	if intent.configPath == "" && !intent.discoverConfig {
-		configSource = "flags-only"
-	}
 	selected := resolvedProfile{profile: Profile{}}
 	if intent.profileSet || intent.configPath != "" || intent.discoverConfig {
 		registry, loadedConfig, err := loadConfigs(cwd, intent.configPath, intent.discoverConfig)

--- a/internal/profiles/resolver_test.go
+++ b/internal/profiles/resolver_test.go
@@ -164,8 +164,8 @@ profiles:
 	if got := strings.Join(opts.Scanners, ","); got != "clawscan-static" {
 		t.Fatalf("scanners = %q", got)
 	}
-	if opts.ConfigSource != "flags-only" {
-		t.Fatalf("config source = %q, want flags-only", opts.ConfigSource)
+	if opts.ConfigSource != "" {
+		t.Fatalf("config source = %q, want empty for a flags-only run", opts.ConfigSource)
 	}
 }
 

--- a/internal/profiles/resolver_test.go
+++ b/internal/profiles/resolver_test.go
@@ -20,6 +20,9 @@ func TestResolveArgsUsesEmbeddedClawHubProfile(t *testing.T) {
 	if opts.Target != "./skill" {
 		t.Fatalf("target = %q", opts.Target)
 	}
+	if opts.ConfigSource != "built-in" {
+		t.Fatalf("config source = %q, want built-in", opts.ConfigSource)
+	}
 	if got := strings.Join(opts.Scanners, ","); got != "skillspector,clawscan-static" {
 		t.Fatalf("scanners = %q", got)
 	}
@@ -162,6 +165,32 @@ profiles:
 	}
 	if opts.IgnoredConfig != filepath.Join(dir, ".clawscan.yml") {
 		t.Fatalf("ignored config = %q, want %s", opts.IgnoredConfig, filepath.Join(dir, ".clawscan.yml"))
+	}
+}
+
+func TestResolveArgsBuiltInProfileProvenanceSurvivesDiscoveredConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".clawscan.yml"), `version: 1
+profiles:
+  unrelated:
+    scanners:
+      - clawscan-static
+`)
+
+	opts, err := ResolveArgs([]string{"./skill", "--profile", "clawhub", "--discover-config"}, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.ConfigSource != "built-in" {
+		t.Fatalf("config source = %q, want built-in (unrelated discovered config must not claim provenance)", opts.ConfigSource)
+	}
+
+	opts, err = ResolveArgs([]string{"./skill", "--profile", "clawhub", "--discover-config"}, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.ConfigSource != "built-in" {
+		t.Fatalf("config source = %q, want built-in when discovery finds nothing", opts.ConfigSource)
 	}
 }
 

--- a/internal/profiles/resolver_test.go
+++ b/internal/profiles/resolver_test.go
@@ -261,13 +261,16 @@ profiles:
 	}
 }
 
-func TestResolveArgsDiscoverConfigWithoutConfigLeavesSourceEmpty(t *testing.T) {
-	opts, err := ResolveArgs([]string{"./skill", "--scanner", "clawscan-static", "--discover-config"}, t.TempDir())
-	if err != nil {
-		t.Fatal(err)
+func TestResolveArgsDiscoverConfigRequiresProfile(t *testing.T) {
+	// Without a profile the run would record the discovered file as its
+	// ConfigSource while applying none of its settings (sandbox mode/image/
+	// env); rejecting is honest, silently ignoring the config is not.
+	_, err := ResolveArgs([]string{"./skill", "--scanner", "clawscan-static", "--discover-config"}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for --discover-config without --profile")
 	}
-	if opts.ConfigSource != "" {
-		t.Fatalf("config source = %q, want empty", opts.ConfigSource)
+	if !strings.Contains(err.Error(), "--discover-config requires --profile") {
+		t.Fatalf("err = %v", err)
 	}
 }
 

--- a/internal/profiles/resolver_test.go
+++ b/internal/profiles/resolver_test.go
@@ -165,6 +165,28 @@ profiles:
 	}
 }
 
+func TestResolveArgsUnknownProfileMentionsIgnoredConfig(t *testing.T) {
+	dir := t.TempDir()
+	config := filepath.Join(dir, ".clawscan.yml")
+	writeFile(t, config, `version: 1
+profiles:
+  custom:
+    scanners:
+      - virustotal
+`)
+
+	_, err := ResolveArgs([]string{"./skill", "--profile", "custom"}, dir)
+	if err == nil {
+		t.Fatal("expected unknown profile error")
+	}
+	if !strings.Contains(err.Error(), "Unknown profile: custom") {
+		t.Fatalf("error = %q, want unknown profile", err)
+	}
+	if !strings.Contains(err.Error(), config) || !strings.Contains(err.Error(), "--discover-config") {
+		t.Fatalf("error = %q, want ignored-config hint naming %s and --discover-config", err, config)
+	}
+}
+
 func TestResolveArgsDefaultRunDoesNotAutoDiscover_WithParentConfig(t *testing.T) {
 	parent := t.TempDir()
 	config := filepath.Join(parent, ".clawscan.yml")

--- a/internal/profiles/resolver_test.go
+++ b/internal/profiles/resolver_test.go
@@ -140,6 +140,142 @@ func TestResolveArgsTreatsScannerOnlyCommandAsAdHocWithoutDefaultJudge(t *testin
 	}
 }
 
+func TestResolveArgsDefaultRunDoesNotAutoDiscover_WithCwdConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".clawscan.yml"), `version: 1
+profiles:
+  custom:
+    scanners:
+      - virustotal
+`)
+
+	opts, err := ResolveArgs([]string{"./skill", "--scanner", "clawscan-static"}, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := strings.Join(opts.Scanners, ","); got != "clawscan-static" {
+		t.Fatalf("scanners = %q", got)
+	}
+	if opts.ConfigSource != "flags-only" {
+		t.Fatalf("config source = %q, want flags-only", opts.ConfigSource)
+	}
+	if opts.IgnoredConfig != filepath.Join(dir, ".clawscan.yml") {
+		t.Fatalf("ignored config = %q, want %s", opts.IgnoredConfig, filepath.Join(dir, ".clawscan.yml"))
+	}
+}
+
+func TestResolveArgsDefaultRunDoesNotAutoDiscover_WithParentConfig(t *testing.T) {
+	parent := t.TempDir()
+	config := filepath.Join(parent, ".clawscan.yml")
+	writeFile(t, config, "version: 1\nprofiles: {}\n")
+	child := filepath.Join(parent, "child")
+	if err := os.Mkdir(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts, err := ResolveArgs([]string{"./skill", "--scanner", "clawscan-static"}, child)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if opts.IgnoredConfig != config {
+		t.Fatalf("ignored config = %q, want %q", opts.IgnoredConfig, config)
+	}
+}
+
+func TestResolveArgsDiscoverConfigFlag_RestoresOldBehavior(t *testing.T) {
+	dir := t.TempDir()
+	config := filepath.Join(dir, ".clawscan.yml")
+	writeFile(t, config, `version: 1
+profiles:
+  custom:
+    scanners:
+      - clawscan-static
+`)
+
+	opts, err := ResolveArgs([]string{"./skill", "--profile", "custom", "--discover-config"}, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if opts.Profile != "custom" {
+		t.Fatalf("profile = %q", opts.Profile)
+	}
+	if opts.ConfigSource != config {
+		t.Fatalf("config source = %q, want %q", opts.ConfigSource, config)
+	}
+	if !opts.DiscoverConfig {
+		t.Fatal("DiscoverConfig = false, want true")
+	}
+}
+
+func TestResolveArgsDiscoverConfigWithoutConfigLeavesSourceEmpty(t *testing.T) {
+	opts, err := ResolveArgs([]string{"./skill", "--scanner", "clawscan-static", "--discover-config"}, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.ConfigSource != "" {
+		t.Fatalf("config source = %q, want empty", opts.ConfigSource)
+	}
+}
+
+func TestResolveArgsConfigAndDiscoverConfigFlagsAreMutuallyExclusive(t *testing.T) {
+	dir := t.TempDir()
+	_, err := ResolveArgs([]string{"./skill", "--config", "config.yml", "--discover-config", "--scanner", "clawscan-static"}, dir)
+	if err == nil {
+		t.Fatal("expected error for --config and --discover-config together")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestResolveArgsExplicitConfigSkipsDiscoveryAndPrintsNoNotice(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".clawscan.yml"), `version: 1
+profiles:
+  builtin:
+    scanners:
+      - clawscan-static
+`)
+	explicit := filepath.Join(dir, "custom.yml")
+	writeFile(t, explicit, `version: 1
+profiles:
+  custom:
+    scanners:
+      - virustotal
+`)
+
+	opts, err := ResolveArgs([]string{"./skill", "--config", explicit, "--profile", "custom"}, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if opts.ConfigSource != explicit {
+		t.Fatalf("config source = %q", opts.ConfigSource)
+	}
+	if opts.IgnoredConfig != "" {
+		t.Fatalf("ignored config = %q, want empty", opts.IgnoredConfig)
+	}
+}
+
+func TestResolveArgsNoConfigAnywherePrintsNoNotice(t *testing.T) {
+	dir := t.TempDir()
+
+	opts, err := ResolveArgs([]string{"./skill", "--scanner", "clawscan-static"}, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if opts.ConfigSource != "flags-only" {
+		t.Fatalf("config source = %q", opts.ConfigSource)
+	}
+	if opts.IgnoredConfig != "" {
+		t.Fatalf("ignored config = %q, want empty", opts.IgnoredConfig)
+	}
+}
+
 func TestResolveArgsAllowsExplicitProfileWithoutTarget(t *testing.T) {
 	dir := t.TempDir()
 
@@ -319,7 +455,7 @@ profiles:
     json: true
 `)
 
-	opts, err := ResolveArgs([]string{"./skill", "--profile", "clawhub"}, child)
+	opts, err := ResolveArgs([]string{"./skill", "--profile", "clawhub", "--discover-config"}, child)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -388,7 +524,7 @@ func TestResolveArgsRejectsAmbiguousDiscoveredConfig(t *testing.T) {
 	writeFile(t, filepath.Join(dir, ".clawscan.yml"), "version: 1\nprofiles: {}\n")
 	writeFile(t, filepath.Join(dir, ".clawscan.yaml"), "version: 1\nprofiles: {}\n")
 
-	_, err := ResolveArgs([]string{"./skill", "--profile", "clawhub"}, dir)
+	_, err := ResolveArgs([]string{"./skill", "--profile", "clawhub", "--discover-config"}, dir)
 	if err == nil || !strings.Contains(err.Error(), "Ambiguous ClawScan config files") {
 		t.Fatalf("err = %v", err)
 	}
@@ -401,7 +537,7 @@ func TestResolveArgsRejectsMalformedYAML(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".clawscan.yml"), "version: [\n")
 
-	_, err := ResolveArgs([]string{"./skill", "--profile", "clawhub"}, dir)
+	_, err := ResolveArgs([]string{"./skill", "--profile", "clawhub", "--discover-config"}, dir)
 	if err == nil || !strings.Contains(err.Error(), "parse ClawScan config") {
 		t.Fatalf("err = %v", err)
 	}
@@ -502,7 +638,7 @@ profiles:
         - ANTHROPIC_API_KEY
 `)
 
-	opts, err := ResolveArgs([]string{"./skill", "--profile", "review"}, dir)
+	opts, err := ResolveArgs([]string{"./skill", "--profile", "review", "--discover-config"}, dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -565,7 +701,7 @@ profiles:
       OPENAI_API_KEY: secret
 `)
 
-	_, err := ResolveArgs([]string{"./skill", "--profile", "bad"}, dir)
+	_, err := ResolveArgs([]string{"./skill", "--profile", "bad", "--discover-config"}, dir)
 	if err == nil || !strings.Contains(err.Error(), "field env not found") {
 		t.Fatalf("err = %v", err)
 	}
@@ -582,7 +718,7 @@ profiles:
       - clawscan-static
 `)
 
-	_, err := ResolveArgs([]string{"./skill", "--profile", "dup"}, dir)
+	_, err := ResolveArgs([]string{"./skill", "--profile", "dup", "--discover-config"}, dir)
 	if err == nil || err.Error() != "Duplicate scanner in profile dup: clawscan-static" {
 		t.Fatalf("err = %v", err)
 	}
@@ -597,12 +733,12 @@ profiles:
     json: true
 `)
 
-	_, err := ResolveArgs([]string{"./skill", "--profile", "empty"}, dir)
+	_, err := ResolveArgs([]string{"./skill", "--profile", "empty", "--discover-config"}, dir)
 	if err == nil || err.Error() != "Profile empty must include at least one scanner or use --scanner" {
 		t.Fatalf("err = %v", err)
 	}
 
-	opts, err := ResolveArgs([]string{"./skill", "--profile", "empty", "--scanner", "clawscan-static"}, dir)
+	opts, err := ResolveArgs([]string{"./skill", "--profile", "empty", "--scanner", "clawscan-static", "--discover-config"}, dir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/profiles/resolver_test.go
+++ b/internal/profiles/resolver_test.go
@@ -143,14 +143,18 @@ func TestResolveArgsTreatsScannerOnlyCommandAsAdHocWithoutDefaultJudge(t *testin
 	}
 }
 
-func TestResolveArgsDefaultRunDoesNotAutoDiscover_WithCwdConfig(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, ".clawscan.yml"), `version: 1
+func TestResolveArgsFlagsOnlyRunIgnoresAncestorConfig(t *testing.T) {
+	parent := t.TempDir()
+	writeFile(t, filepath.Join(parent, ".clawscan.yml"), `version: 1
 profiles:
   custom:
     scanners:
       - virustotal
 `)
+	dir := filepath.Join(parent, "child")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	opts, err := ResolveArgs([]string{"./skill", "--scanner", "clawscan-static"}, dir)
 	if err != nil {
@@ -162,9 +166,6 @@ profiles:
 	}
 	if opts.ConfigSource != "flags-only" {
 		t.Fatalf("config source = %q, want flags-only", opts.ConfigSource)
-	}
-	if opts.IgnoredConfig != filepath.Join(dir, ".clawscan.yml") {
-		t.Fatalf("ignored config = %q, want %s", opts.IgnoredConfig, filepath.Join(dir, ".clawscan.yml"))
 	}
 }
 
@@ -194,10 +195,9 @@ profiles:
 	}
 }
 
-func TestResolveArgsUnknownProfileMentionsIgnoredConfig(t *testing.T) {
+func TestResolveArgsUnknownProfileDoesNotDiscoverConfig(t *testing.T) {
 	dir := t.TempDir()
-	config := filepath.Join(dir, ".clawscan.yml")
-	writeFile(t, config, `version: 1
+	writeFile(t, filepath.Join(dir, ".clawscan.yml"), `version: 1
 profiles:
   custom:
     scanners:
@@ -208,30 +208,9 @@ profiles:
 	if err == nil {
 		t.Fatal("expected unknown profile error")
 	}
-	if !strings.Contains(err.Error(), "Unknown profile: custom") {
-		t.Fatalf("error = %q, want unknown profile", err)
-	}
-	if !strings.Contains(err.Error(), config) || !strings.Contains(err.Error(), "--discover-config") {
-		t.Fatalf("error = %q, want ignored-config hint naming %s and --discover-config", err, config)
-	}
-}
-
-func TestResolveArgsDefaultRunDoesNotAutoDiscover_WithParentConfig(t *testing.T) {
-	parent := t.TempDir()
-	config := filepath.Join(parent, ".clawscan.yml")
-	writeFile(t, config, "version: 1\nprofiles: {}\n")
-	child := filepath.Join(parent, "child")
-	if err := os.Mkdir(child, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	opts, err := ResolveArgs([]string{"./skill", "--scanner", "clawscan-static"}, child)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if opts.IgnoredConfig != config {
-		t.Fatalf("ignored config = %q, want %q", opts.IgnoredConfig, config)
+	want := "Unknown profile: custom (available: clawhub, clawhub-aig)"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err, want)
 	}
 }
 
@@ -285,7 +264,7 @@ func TestResolveArgsConfigAndDiscoverConfigFlagsAreMutuallyExclusive(t *testing.
 	}
 }
 
-func TestResolveArgsExplicitConfigSkipsDiscoveryAndPrintsNoNotice(t *testing.T) {
+func TestResolveArgsExplicitConfigUsesExplicitSource(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, ".clawscan.yml"), `version: 1
 profiles:
@@ -308,25 +287,6 @@ profiles:
 
 	if opts.ConfigSource != explicit {
 		t.Fatalf("config source = %q", opts.ConfigSource)
-	}
-	if opts.IgnoredConfig != "" {
-		t.Fatalf("ignored config = %q, want empty", opts.IgnoredConfig)
-	}
-}
-
-func TestResolveArgsNoConfigAnywherePrintsNoNotice(t *testing.T) {
-	dir := t.TempDir()
-
-	opts, err := ResolveArgs([]string{"./skill", "--scanner", "clawscan-static"}, dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if opts.ConfigSource != "flags-only" {
-		t.Fatalf("config source = %q", opts.ConfigSource)
-	}
-	if opts.IgnoredConfig != "" {
-		t.Fatalf("ignored config = %q, want empty", opts.IgnoredConfig)
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -28,6 +28,9 @@ import (
 type Options struct {
 	Target             string
 	Profile            string
+	ConfigSource       string
+	DiscoverConfig     bool
+	IgnoredConfig      string
 	ContextPath        string
 	Benchmark          *BenchmarkOptions
 	Scanners           []string
@@ -87,6 +90,7 @@ type CommandOutput struct {
 type Artifact struct {
 	SchemaVersion string                   `json:"schemaVersion"`
 	Profile       string                   `json:"profile,omitempty"`
+	ConfigSource  string                   `json:"configSource,omitempty"`
 	Context       json.RawMessage          `json:"context,omitempty"`
 	Target        Target                   `json:"target"`
 	StartedAt     string                   `json:"startedAt"`
@@ -2117,6 +2121,7 @@ func NewArtifact(opts Options, resolvedPath string, startedAt string, completedA
 	return Artifact{
 		SchemaVersion: "clawscan-run-v1",
 		Profile:       opts.Profile,
+		ConfigSource:  opts.ConfigSource,
 		Target: Target{
 			Kind:         "skill",
 			Input:        opts.Target,

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -87,17 +87,19 @@ type CommandOutput struct {
 }
 
 type Artifact struct {
-	SchemaVersion string                   `json:"schemaVersion"`
-	Profile       string                   `json:"profile,omitempty"`
-	ConfigSource  string                   `json:"configSource,omitempty"`
-	Context       json.RawMessage          `json:"context,omitempty"`
-	Target        Target                   `json:"target"`
-	StartedAt     string                   `json:"startedAt"`
-	CompletedAt   string                   `json:"completedAt"`
-	Env           map[string]string        `json:"env"`
-	Sandbox       SandboxMetadata          `json:"sandbox"`
-	Scanners      map[string]ScannerResult `json:"scanners"`
-	Judge         *JudgeResult             `json:"judge"`
+	SchemaVersion string `json:"schemaVersion"`
+	Profile       string `json:"profile,omitempty"`
+	// ConfigSource deliberately lacks omitempty: null positively claims no config
+	// influenced the run, unlike older artifacts that omitted the field.
+	ConfigSource *string                  `json:"configSource"`
+	Context      json.RawMessage          `json:"context,omitempty"`
+	Target       Target                   `json:"target"`
+	StartedAt    string                   `json:"startedAt"`
+	CompletedAt  string                   `json:"completedAt"`
+	Env          map[string]string        `json:"env"`
+	Sandbox      SandboxMetadata          `json:"sandbox"`
+	Scanners     map[string]ScannerResult `json:"scanners"`
+	Judge        *JudgeResult             `json:"judge"`
 }
 
 type RunTargetsResult struct {
@@ -2117,10 +2119,15 @@ func NewArtifact(opts Options, resolvedPath string, startedAt string, completedA
 			Raw:         nil,
 		}
 	}
+	var configSource *string
+	if opts.ConfigSource != "" {
+		source := opts.ConfigSource
+		configSource = &source
+	}
 	return Artifact{
 		SchemaVersion: "clawscan-run-v1",
 		Profile:       opts.Profile,
-		ConfigSource:  opts.ConfigSource,
+		ConfigSource:  configSource,
 		Target: Target{
 			Kind:         "skill",
 			Input:        opts.Target,

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -30,7 +30,6 @@ type Options struct {
 	Profile            string
 	ConfigSource       string
 	DiscoverConfig     bool
-	IgnoredConfig      string
 	ContextPath        string
 	Benchmark          *BenchmarkOptions
 	Scanners           []string

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1105,28 +1105,19 @@ func TestArtifactConfigSourceField_FlagsOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	opts.ConfigSource = "flags-only"
+	opts.ConfigSource = ""
 
 	artifact := NewArtifact(opts, "/tmp/my-skill", "2026-06-03T00:00:00Z", "2026-06-03T00:00:01Z", map[string]string{})
 
-	if artifact.ConfigSource != "flags-only" {
-		t.Fatalf("config source = %q", artifact.ConfigSource)
+	if artifact.ConfigSource != nil {
+		t.Fatalf("config source = %q, want nil", *artifact.ConfigSource)
 	}
-}
-
-func TestArtifactConfigSourceField_OmitsEmptySource(t *testing.T) {
-	opts, err := ParseArgs([]string{"./my-skill", "--scanner", "clawscan-static"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	artifact := NewArtifact(opts, "/tmp/my-skill", "2026-06-03T00:00:00Z", "2026-06-03T00:00:01Z", map[string]string{})
 	raw, err := json.Marshal(artifact)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Contains(raw, []byte(`"configSource"`)) {
-		t.Fatalf("empty config source was serialized: %s", raw)
+	if !strings.Contains(string(raw), `"configSource":null`) {
+		t.Fatalf("artifact lacks explicit null config source: %s", raw)
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1100,6 +1100,36 @@ func TestArtifactRedactsEnvValues(t *testing.T) {
 	}
 }
 
+func TestArtifactConfigSourceField_FlagsOnly(t *testing.T) {
+	opts, err := ParseArgs([]string{"./my-skill", "--scanner", "clawscan-static"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts.ConfigSource = "flags-only"
+
+	artifact := NewArtifact(opts, "/tmp/my-skill", "2026-06-03T00:00:00Z", "2026-06-03T00:00:01Z", map[string]string{})
+
+	if artifact.ConfigSource != "flags-only" {
+		t.Fatalf("config source = %q", artifact.ConfigSource)
+	}
+}
+
+func TestArtifactConfigSourceField_OmitsEmptySource(t *testing.T) {
+	opts, err := ParseArgs([]string{"./my-skill", "--scanner", "clawscan-static"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	artifact := NewArtifact(opts, "/tmp/my-skill", "2026-06-03T00:00:00Z", "2026-06-03T00:00:01Z", map[string]string{})
+	raw, err := json.Marshal(artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte(`"configSource"`)) {
+		t.Fatalf("empty config source was serialized: %s", raw)
+	}
+}
+
 func TestRunWritesScannerOnlyArtifact(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "skill")

--- a/skills/clawscan-cli/SKILL.md
+++ b/skills/clawscan-cli/SKILL.md
@@ -83,11 +83,13 @@ Built-in profiles:
 | --- | --- | --- |
 | `clawhub` | `skillspector`, `clawscan-static` | bundled Codex judge with ClawHub prompt/schema |
 
-Profiles are loaded from embedded built-ins plus the nearest `.clawscan.yml` or
-`.clawscan.yaml` discovered upward from the current directory. A project profile
-with the same name shadows the built-in whole profile. `--config <path>` loads a
-specific config; without `--profile`, it runs every profile in that config and
-emits a `clawscan-batch-v1` artifact.
+Profiles are loaded from embedded built-ins. Project `.clawscan.yml` /
+`.clawscan.yaml` files are NOT loaded automatically: pass `--config <path>` to
+load a specific config, or `--discover-config` to load the nearest one found
+upward from the current directory. A project profile with the same name shadows
+the built-in whole profile. `--config <path>` without `--profile` runs every
+profile in that config and emits a `clawscan-batch-v1` artifact. When a run
+skips a discovered config, clawscan prints a stderr notice naming the file.
 
 Use `clawscan profiles` to inspect the resolved built-in plus nearest local
 profile catalog. Use `clawscan profiles -v` to print the merged catalog as

--- a/skills/clawscan-cli/SKILL.md
+++ b/skills/clawscan-cli/SKILL.md
@@ -88,12 +88,12 @@ Profiles are loaded from embedded built-ins. Project `.clawscan.yml` /
 load a specific config, or `--discover-config` to load the nearest one found
 upward from the current directory. A project profile with the same name shadows
 the built-in whole profile. `--config <path>` without `--profile` runs every
-profile in that config and emits a `clawscan-batch-v1` artifact. When a run
-skips a discovered config, clawscan prints a stderr notice naming the file.
+profile in that config and emits a `clawscan-batch-v1` artifact. Discovery is
+off by default because project configs can define scanner commands that execute
+with the caller's environment and credentials.
 
-Use `clawscan profiles` to inspect the resolved built-in plus nearest local
-profile catalog. Use `clawscan profiles -v` to print the merged catalog as
-pasteable YAML.
+Use `clawscan profiles` to inspect the built-in profile catalog. Use
+`clawscan profiles -v` to print it as pasteable YAML.
 
 CLI flags override the selected profile for one run. Passing `--scanner`
 without `--profile` creates an ad hoc scanner-only run, so profile judges are


### PR DESCRIPTION
## New behavior

ClawScan never loads — or even looks for — `.clawscan.yml` files it was not explicitly told to trust. Operators name their config (`--config <path>`) or opt in to upward-walk discovery (`--discover-config`, which requires `--profile`); otherwise flags-only and built-in-profile runs do no config discovery I/O at all and print nothing about nearby config files. Run artifacts record where the effective config came from (`configSource`: a path, `built-in`, or explicit JSON `null` when no config participated — the field is never omitted, so an artifact always self-describes).

- A flags-only run in a directory containing a `.clawscan.yml` ignores it silently: no upward walk, no stderr notice, `configSource: null`.
- `--profile <name>` where the profile lives in an undiscovered config fails with `Unknown profile: <name> (available: clawhub, clawhub-aig)` — no filesystem traversal to hint at nearby files.
- `--discover-config` restores the old upward-walk behavior for a single run. It is mutually exclusive with `--config` and requires `--profile` (discovery without a profile would record the file as `configSource` while applying none of it).
- Built-in profiles (`--profile clawhub`) record `configSource: built-in` even when `--discover-config` finds an unrelated project config.
- `clawscan profiles` lists built-in profiles only, each marked `Source: built-in`.

**Breaking change** for anyone relying on silent repo-root `.clawscan.yml` pickup. Migration: pass `--config <path>` or `--profile <name> --discover-config`.

## Why

Groundwork for user-defined (command-backed) scanners: config discovered from a scan target must never gain the power to execute commands an attacker chose by dropping a `.clawscan.yml` into a skill. If ClawScan deliberately does not trust a config, it also does not spend I/O finding it or mention it — a notice naming the file would itself be attacker-influenced output. Precedent: git, VS Code Workspace Trust, direnv, Trivy, and Grype all refuse discovered executable config; ESLint's implicit config trust is the cautionary tale.

## CLI proof

Before — PR base silently auto-discovers `.clawscan.yml` and resolves the `team-policy` profile from it with no notice:

![Base binary silently loading a discovered .clawscan.yml](https://github.com/user-attachments/assets/6ab98f6f-805e-405e-b9aa-00652668d1c6)

**What this shows:** `clawscan ./README.md --profile team-policy --json` on the PR base finds the config via upward walk and runs the profile without any indication a file was trusted.

**State:** demo directory containing `README.md` and a `.clawscan.yml` defining `team-policy`; binary built from the PR base (`main` @ a37f49f); 114×31 terminal window capture.

Now — the same directory: the local config is ignored with no notice, and the run records `configSource: null`:

![PR binary silently ignoring the local config](https://github.com/user-attachments/assets/d873e0a7-1122-4d45-ab9c-fb9cc3bba845)

**What this shows:** `ls -a` shows `.clawscan.yml` sitting next to the target; `clawscan ./README.md --scanner clawscan-static --json` produces JSON with `"configSource": null` and prints nothing to stderr — untrusted config is neither loaded nor mentioned.

**State:** same demo directory; binary built from this PR's head; 80×24 terminal window capture.

Now — asking for a profile that lives in the undiscovered config fails plainly, and `--discover-config` opts back in:

![Unknown-profile error, then opt-in discovery resolving the profile](https://github.com/user-attachments/assets/cff2cc9f-1ba2-49c8-810e-298e120fcd91)

**What this shows:** `clawscan ./README.md --profile team-policy` fails with `Unknown profile: team-policy (available: clawhub, clawhub-aig)` — no traversal, no mention of the nearby file. The same command with `--discover-config --json` loads the config and runs with `"profile": "team-policy"`.

**State:** same demo directory and PR-head binary; 114×31 terminal window capture.

## How to verify

1. In a directory with a `.clawscan.yml` defining a profile, run `clawscan <file> --scanner clawscan-static --json 2>err.txt` — expect normal JSON with `"configSource": null` and an empty `err.txt`.
2. Run `clawscan <file> --profile <that-profile>` — expect `Unknown profile: <that-profile> (available: clawhub, clawhub-aig)` with no mention of the local file.
3. Add `--discover-config` — expect the profile to resolve and the artifact's `configSource` to record the loaded path.
4. Run `clawscan <file> --profile clawhub` — expect `configSource: "built-in"` in the artifact.
5. Run `clawscan profiles` in that directory — expect built-ins only, `Source: built-in`.

## Checks

- Resolver tests cover: no discovery from cwd or parents (`TestResolveArgsDefaultRunDoesNotAutoDiscover_*`), `--discover-config` restoring the walk, its `--profile` requirement, mutual exclusion with `--config`, the plain unknown-profile error (`TestResolveArgsUnknownProfileDoesNotDiscoverConfig`), and `configSource` provenance (loaded path / `built-in` / explicit `null`).
- CLI tests assert flags-only runs emit nothing to stderr about nearby configs.
- `go test -count=1 ./...` — passes except two pre-existing macOS `/var`-symlink failures in `target_test.go` unrelated to this change.
- `go vet ./...`, `gofmt`, `make docs-site` — clean.

