### PR TITLE
sec (4/9): scope benchmark requirement preflight to runnable scanners

### DIFF
--- a/internal/runner/benchmark.go
+++ b/internal/runner/benchmark.go
@@ -191,6 +191,20 @@ type huggingFaceRow struct {
 	Row OpenClawBenchmarkRow `json:"row"`
 }
 
+// runnableBenchmarkScanners filters requested scanners to those supporting the
+// benchmark's per-case target kind, so requirement validation does not abort on
+// a scanner (e.g. url-only) that would never run against these cases anyway.
+func runnableBenchmarkScanners(opts Options, kind string) []string {
+	registry := registryForOptions(opts)
+	runnable := make([]string, 0, len(opts.Scanners))
+	for _, id := range opts.Scanners {
+		if scannerSupportsTargetKindInRegistry(registry, id, kind) {
+			runnable = append(runnable, id)
+		}
+	}
+	return runnable
+}
+
 func RunBenchmark(opts Options, ctx RunContext) (BenchmarkArtifact, error) {
 	if opts.Benchmark == nil {
 		return BenchmarkArtifact{}, errors.New("missing benchmark options")
@@ -213,7 +227,9 @@ func RunBenchmark(opts Options, ctx RunContext) (BenchmarkArtifact, error) {
 		env = EnvMap(os.Environ())
 	}
 	applyRuntimeEnvDefaults(opts, env)
-	if err := ValidateRequirements(opts, env); err != nil {
+	requirementOpts := opts
+	requirementOpts.Scanners = runnableBenchmarkScanners(opts, "skill")
+	if err := ValidateRequirements(requirementOpts, env); err != nil {
 		return BenchmarkArtifact{}, err
 	}
 	if opts.Benchmark.IDsSource != "" {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -850,6 +850,27 @@ func TestValidateRequirements(t *testing.T) {
 	}
 }
 
+func TestRunnableBenchmarkScannersFiltersUnsupportedTargetKind(t *testing.T) {
+	skillScanner := NewUserDefinedScanner(UserDefinedScannerConfig{
+		ID: "skillscan", Command: "run {{target}}", Targets: []string{"skill"},
+	})
+	urlScanner := NewUserDefinedScanner(UserDefinedScannerConfig{
+		ID: "urlscan", Command: "run {{target}}", Targets: []string{"url"},
+	})
+	registry, err := NewScannerRegistry(skillScanner, urlScanner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{
+		Scanners:        []string{"skillscan", "urlscan"},
+		ScannerRegistry: registry,
+	}
+	runnable := runnableBenchmarkScanners(opts, "skill")
+	if len(runnable) != 1 || runnable[0] != "skillscan" {
+		t.Fatalf("runnable = %#v, want [skillscan]", runnable)
+	}
+}
+
 func TestValidateRequirementsSkipsScannerResultCredentials(t *testing.T) {
 	opts, err := ParseArgs([]string{
 		"./my-skill",


### PR DESCRIPTION
## What changes

Benchmark **requirement preflight** now only considers scanners that can
actually run on the benchmark's target kind. A scanner that does not support the
target kind (e.g. a plugin-only scanner during a skill benchmark) no longer has
its required env vars demanded before the run starts.

## Why it matters

Preflight fails fast when a required credential is missing — good. But it was
checking *every* configured scanner, including ones that would be skipped anyway
because they don't support the target kind. That meant a benchmark could abort
demanding, say, a token for a scanner that was never going to execute. Scoping
preflight to the runnable set makes the "fail before partial work" check match
the work that will actually happen.

## Before / after

| | Behavior |
|---|---|
| **Before** | preflight requires env for **all** configured scanners, including unrunnable ones — benchmark aborts on a credential it will never use |
| **After** | preflight requires env only for scanners that support the benchmark target kind |

New helper `runnableBenchmarkScanners(opts, kind)` filters the scanner set via
the registry's `SupportsTargetKind` before requirement resolution; `RunBenchmark`
feeds that filtered set into preflight.

## Verify

```
go test ./internal/runner/ -run 'RunnableBenchmarkScanners' -count=1
```

`TestRunnableBenchmarkScannersFiltersUnsupportedTargetKind` asserts a scanner
that does not support the target kind is dropped from the preflight set.
