### PR TITLE
sec (5/9): reject unsafe targets on the Windows host shell

### DIFF
--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -871,6 +871,30 @@ func TestRunnableBenchmarkScannersFiltersUnsupportedTargetKind(t *testing.T) {
 	}
 }
 
+func TestUnsafeWindowsShellTargetDetectsInjectionCharacters(t *testing.T) {
+	unsafe := []string{
+		`%PATH%`,
+		`!DELAYED!`,
+		`skill" & calc.exe`,
+		`C:\skills\a"b`,
+	}
+	for _, target := range unsafe {
+		if !unsafeWindowsShellTarget(target) {
+			t.Errorf("unsafeWindowsShellTarget(%q) = false, want true", target)
+		}
+	}
+	safe := []string{
+		`https://example.com/skill`,
+		`C:\skills\my-skill`,
+		`./local/skill`,
+	}
+	for _, target := range safe {
+		if unsafeWindowsShellTarget(target) {
+			t.Errorf("unsafeWindowsShellTarget(%q) = true, want false", target)
+		}
+	}
+}
+
 func TestValidateRequirementsSkipsScannerResultCredentials(t *testing.T) {
 	opts, err := ParseArgs([]string{
 		"./my-skill",

--- a/internal/runner/user_defined_scanner.go
+++ b/internal/runner/user_defined_scanner.go
@@ -56,12 +56,26 @@ func (adapter userDefinedScannerAdapter) SupportsTargetKind(kind string) bool {
 
 func (adapter userDefinedScannerAdapter) CommandBacked() bool { return true }
 
+// unsafeWindowsShellTarget reports whether a target cannot be interpolated into
+// a cmd.exe command line safely: %VAR% expands even inside double quotes, !VAR!
+// does too when delayed expansion is enabled, and backslash does not escape "
+// for cmd.exe, so a quote in a target could terminate the argument and inject
+// host commands.
+func unsafeWindowsShellTarget(target string) bool {
+	return strings.ContainsAny(target, "%\"!")
+}
+
 func (adapter userDefinedScannerAdapter) Run(runner ExternalScannerRunner, target string, startedAt string) (ScannerResult, error) {
 	shell := userDefinedScannerShell(runtime.GOOS, runner.SandboxMode)
 	targetReplacement := shell.quote(target)
 	usePositionalTarget := shell.command == "/bin/sh"
 	if usePositionalTarget {
 		targetReplacement = `"$1"`
+	} else if unsafeWindowsShellTarget(target) {
+		return ScannerResult{
+			Status: "failed", StartedAt: startedAt, CompletedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			Error: fmt.Sprintf(`User-defined scanner %s cannot receive targets containing %%, !, or " on the Windows host shell; use the Docker sandbox or a target without those characters`, adapter.config.ID),
+		}, nil
 	}
 	rendered := targetPlaceholderPattern.ReplaceAllStringFunc(adapter.config.Command, func(string) string {
 		return targetReplacement


### PR DESCRIPTION
## What changes

On the **Windows host shell** (`--sandbox off` on Windows), a user-defined
scanner target containing `%`, `"`, or `!` is now rejected instead of being
interpolated into the `cmd.exe` command line.

## Why it matters

`cmd.exe` expands `%VAR%` even inside double quotes, expands `!VAR!` when delayed
expansion is on, and does **not** let backslash escape a `"`. So a target path
containing those characters could break out of the intended argument and inject
host commands. Since a target name/path can come from untrusted skill content,
that is a command-injection vector on Windows. Rejecting those characters closes
it. This affects only the Windows *host* shell path — the Docker sandbox (the
default) and POSIX hosts pass the target as a positional `"$1"` argument and are
unaffected.

## Before / after

| Target on Windows host | Before | After |
|---|---|---|
| `skill%PATH%.md` | interpolated into `cmd.exe` line — expansion/injection risk | scanner result `failed`, no command run |
| `plain-skill.md` | runs | runs (unchanged) |

The guard is `unsafeWindowsShellTarget(target)`; it fires only when the resolved
shell is the Windows host shell, so Docker/POSIX behavior is untouched.

## Verify

```
go test ./internal/runner/ -run 'UnsafeWindowsShellTarget' -count=1
```

`TestUnsafeWindowsShellTargetDetectsInjectionCharacters` covers `%`, `"`, `!`
(rejected) and safe targets (allowed). Cross-compiles clean:
`GOOS=windows go build ./...`.
