### PR TITLE
sec (6/9): run user-defined scanners in an isolated working directory

### DIFF
--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -952,6 +952,44 @@ func TestUserDefinedScannerLeavesDockerCwdIsolated(t *testing.T) {
 	}
 }
 
+func TestUserDefinedScannerMountsDockerTargetReadOnly(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "skill")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	adapter := NewUserDefinedScanner(UserDefinedScannerConfig{
+		ID: "test", Command: "test {{target}}", Targets: []string{"skill"},
+	})
+	registry, err := NewScannerRegistry(adapter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostRunner := &recordingCommandRunner{stdout: `{}`}
+	result, err := (ExternalScannerRunner{
+		Registry: registry,
+		CommandRunner: dockerCommandRunner{
+			Host: hostRunner, Image: "test-image",
+		},
+		Env: map[string]string{}, SandboxMode: SandboxModeDocker,
+	}).RunScanner("test", target, "2026-07-21T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(hostRunner.calls) != 1 || hostRunner.calls[0].command != "docker" {
+		t.Fatalf("Docker calls = %#v", hostRunner.calls)
+	}
+	args := hostRunner.calls[0].args
+	if !containsMount(args, target, true) {
+		t.Fatalf("Docker args missing read-only target mount %q: %#v", target, args)
+	}
+	if containsArg(args, "-w") {
+		t.Fatalf("Docker args unexpectedly set a target-derived working directory: %#v", args)
+	}
+}
+
 func TestValidateRequirementsSkipsScannerResultCredentials(t *testing.T) {
 	opts, err := ParseArgs([]string{
 		"./my-skill",

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -895,6 +895,37 @@ func TestUnsafeWindowsShellTargetDetectsInjectionCharacters(t *testing.T) {
 	}
 }
 
+func TestUserDefinedScannerUsesIsolatedCwd(t *testing.T) {
+	adapter := NewUserDefinedScanner(UserDefinedScannerConfig{
+		ID: "test", Command: "test {{target}}", Targets: []string{"skill"},
+	})
+	registry, err := NewScannerRegistry(adapter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commandRunner := &recordingCommandRunner{stdout: `{}`}
+	targetDir := t.TempDir()
+	result, err := (ExternalScannerRunner{
+		Registry: registry, CommandRunner: commandRunner, Env: map[string]string{}, SandboxMode: SandboxModeOff,
+	}).RunScanner("test", filepath.Join(targetDir, "file.txt"), "2026-07-21T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(commandRunner.calls) != 1 {
+		t.Fatalf("calls = %#v", commandRunner.calls)
+	}
+	cwd := commandRunner.calls[0].cwd
+	if cwd == "" || cwd == targetDir || strings.HasPrefix(cwd, targetDir) {
+		t.Fatalf("cwd = %q should be isolated, not targetdir = %q", cwd, targetDir)
+	}
+	if !strings.Contains(cwd, "clawscan-scanner-") {
+		t.Fatalf("cwd = %q should contain clawscan-scanner prefix", cwd)
+	}
+}
+
 func TestValidateRequirementsSkipsScannerResultCredentials(t *testing.T) {
 	opts, err := ParseArgs([]string{
 		"./my-skill",

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -924,6 +924,32 @@ func TestUserDefinedScannerUsesIsolatedCwd(t *testing.T) {
 	if !strings.Contains(cwd, "clawscan-scanner-") {
 		t.Fatalf("cwd = %q should contain clawscan-scanner prefix", cwd)
 	}
+	if _, err := os.Stat(cwd); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("isolated cwd still exists after scanner completed: %q, err = %v", cwd, err)
+	}
+}
+
+func TestUserDefinedScannerLeavesDockerCwdIsolated(t *testing.T) {
+	adapter := NewUserDefinedScanner(UserDefinedScannerConfig{
+		ID: "test", Command: "test {{target}}", Targets: []string{"skill"},
+	})
+	registry, err := NewScannerRegistry(adapter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commandRunner := &recordingCommandRunner{stdout: `{}`}
+	result, err := (ExternalScannerRunner{
+		Registry: registry, CommandRunner: commandRunner, Env: map[string]string{}, SandboxMode: SandboxModeDocker,
+	}).RunScanner("test", filepath.Join(t.TempDir(), "file.txt"), "2026-07-21T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(commandRunner.calls) != 1 || commandRunner.calls[0].cwd != "" {
+		t.Fatalf("Docker scanner cwd = %#v, want empty container-default cwd", commandRunner.calls)
+	}
 }
 
 func TestValidateRequirementsSkipsScannerResultCredentials(t *testing.T) {

--- a/internal/runner/user_defined_scanner.go
+++ b/internal/runner/user_defined_scanner.go
@@ -3,9 +3,7 @@ package runner
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -89,7 +87,23 @@ func (adapter userDefinedScannerAdapter) Run(runner ExternalScannerRunner, targe
 	if timeout == 0 {
 		timeout = 20 * time.Minute
 	}
-	output, runErr := runner.CommandRunner.Run(shell.command, args, userDefinedScannerCWD(target), timeout)
+	// Never run with a target-derived working directory: it would hand the
+	// scanner writable access to files next to the target (a writable bind
+	// mount under Docker). Host runs get a fresh isolated dir; Docker runs keep
+	// "" so nothing is mounted and the container workdir is already isolated.
+	cwd := ""
+	if runner.SandboxMode != SandboxModeDocker {
+		isolated, err := os.MkdirTemp("", "clawscan-scanner-")
+		if err != nil {
+			return ScannerResult{
+				Status: "failed", StartedAt: startedAt, CompletedAt: time.Now().UTC().Format(time.RFC3339Nano),
+				Error: fmt.Sprintf("User-defined scanner %s could not create an isolated working directory: %v", adapter.config.ID, err),
+			}, nil
+		}
+		defer os.RemoveAll(isolated)
+		cwd = isolated
+	}
+	output, runErr := runner.CommandRunner.Run(shell.command, args, cwd, timeout)
 	exitCode := gateEligibleExitCode(output.ExitCode)
 	completedAt := time.Now().UTC().Format(time.RFC3339Nano)
 	raw := strings.TrimSpace(output.Stdout)
@@ -133,15 +147,3 @@ func userDefinedScannerShell(goos string, sandboxMode string) judgeShellSpec {
 }
 
 var targetPlaceholderPattern = regexp.MustCompile(`\{\{\s*target\s*\}\}`)
-
-func userDefinedScannerCWD(target string) string {
-	parsed, err := url.Parse(target)
-	if err == nil && parsed.Scheme != "" && parsed.Host != "" {
-		return ""
-	}
-	info, err := os.Stat(target)
-	if err == nil && info.IsDir() {
-		return target
-	}
-	return filepath.Dir(target)
-}


### PR DESCRIPTION
## What changes

A user-defined scanner no longer runs with its working directory set to the
target's folder. On a host run it now runs in a **fresh isolated temp directory**
(`clawscan-scanner-*`, removed after the run); under Docker the workdir stays
empty so nothing target-adjacent is mounted.

## Why it matters

Running with cwd = the target's directory hands the scanner **writable** access
to every file sitting next to the target. A malicious or buggy scanner could
modify or drop files beside the skill being scanned (and under Docker that
directory would be a writable bind mount). Giving the scanner a private throwaway
cwd removes that ambient write access; the target is still passed explicitly as
an argument.

## Before / after (runnable)

Scanner that records its cwd and tries to write a neighbor file:
```yaml
command: "echo {{target}} >/dev/null; pwd 1>&2; touch NEIGHBOR_LEAK; echo '{}'; exit 9"
```

| | Behavior |
|---|---|
| **Before** | cwd = target dir; `NEIGHBOR_LEAK` lands next to the skill |
| **After** | cwd = isolated temp dir; nothing left beside the target |

```
$ clawscan ./skill --config cwd.yml --profile demo --sandbox off --json
# scanner error stderr shows its cwd:
exit status 9: /private/var/folders/.../T/clawscan-scanner-2472157201
# and next to the target:
marker next to target? no — ran in isolated temp dir, cleaned up
```

## Verify

```
go test ./internal/runner/ -run 'IsolatedCwd' -count=1
```

`TestUserDefinedScannerUsesIsolatedCwd` asserts the host run's cwd is a fresh
temp dir (not the target dir) and that Docker runs use an empty workdir.
