### PR TITLE
docs: rebuild ClawScan site with Carapace

### DIFF
--- a/docs/assets/carapace/LICENSE
+++ b/docs/assets/carapace/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 openclaw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/assets/carapace/SOURCE.md
+++ b/docs/assets/carapace/SOURCE.md
@@ -1,0 +1,11 @@
+# Carapace source
+
+These focused CSS exports are vendored from
+[`openclaw/carapace`](https://github.com/openclaw/carapace) release `v0.6.1`
+(`6c64d6b67edf169c32a452ce8ccdbec65a75bab3`).
+
+The ClawScan static docs builder follows Carapace's consumer guidance by
+loading `tokens.css`, `themes.css`, `typography.css`, and `components.css`
+before the local docs composition in `../site.css`.
+
+See `LICENSE` for the MIT license.

--- a/docs/assets/carapace/components.css
+++ b/docs/assets/carapace/components.css
@@ -1,0 +1,344 @@
+/*
+ * Framework-neutral stable component primitives for OpenClaw surfaces.
+ * This file preserves the v0.0.1 runtime contract.
+ */
+
+.oc-app-surface {
+  --oc-component-surface: var(--oc-surface-card);
+  --oc-component-surface-strong: var(--oc-surface-card-strong);
+  --oc-component-surface-hover: var(--oc-surface-interactive);
+  --oc-component-border: var(--oc-border-subtle);
+  --oc-component-border-hover: color-mix(
+    in srgb,
+    var(--oc-text-primary) 28%,
+    var(--oc-border-subtle)
+    );
+  --oc-component-shadow: var(--oc-shadow-sm);
+  --oc-component-shadow-hover: var(--oc-shadow-md);
+
+  min-width: 0;
+  min-height: 100%;
+  background: var(--oc-bg-page);
+  color: var(--oc-text-primary);
+  font-family: var(--oc-font-body);
+}
+
+.oc-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--oc-space-3);
+  text-align: center;
+}
+
+.oc-hero-title {
+  max-width: 66rem;
+  margin: 0;
+  color: var(--oc-accent-primary);
+  font-family: var(--oc-font-mono);
+  font-size: clamp(2.25rem, 4.25vw, 3.5rem);
+  font-weight: 800;
+  line-height: 1.08;
+  letter-spacing: 0;
+  overflow-wrap: anywhere;
+  text-wrap: balance;
+}
+
+.oc-hero-lede {
+  max-width: 42rem;
+  margin: 0;
+  color: var(--oc-text-secondary);
+  font-size: var(--oc-font-size-lg);
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+
+.oc-section {
+  width: 100%;
+  color: var(--oc-text-primary);
+}
+
+.oc-section-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--oc-space-5);
+}
+
+.oc-section-header > * {
+  min-width: 0;
+}
+
+.oc-section-heading {
+  display: grid;
+  gap: var(--oc-space-2);
+}
+
+.oc-eyebrow {
+  margin: 0;
+  color: var(--oc-accent-primary);
+  font-family: var(--oc-font-mono);
+  font-size: var(--oc-font-size-xs);
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.oc-section-title {
+  margin: 0;
+  color: var(--oc-text-primary);
+  font-family: var(--oc-font-display);
+  font-size: clamp(1.5rem, 2.2vw, 2rem);
+  font-weight: 750;
+  line-height: 1.12;
+  letter-spacing: 0;
+  text-wrap: balance;
+}
+
+.oc-section-copy {
+  max-width: 60ch;
+  margin: 0;
+  color: var(--oc-text-secondary);
+  font-size: var(--oc-font-size-base);
+  line-height: 1.65;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+
+.oc-card {
+  border: 1px solid var(--oc-component-border);
+  border-radius: var(--oc-radius-surface);
+  background: var(--oc-component-surface);
+  color: var(--oc-text-primary);
+  box-shadow: var(--oc-component-shadow);
+}
+
+.oc-card-interactive {
+  transition:
+    background var(--oc-duration-ui) var(--oc-ease-out),
+    border-color var(--oc-duration-ui) var(--oc-ease-out),
+    box-shadow var(--oc-duration-ui) var(--oc-ease-out),
+    transform var(--oc-duration-ui) var(--oc-ease-out);
+}
+
+.oc-card-interactive:hover,
+.oc-card-interactive:focus-visible {
+  border-color: var(--oc-component-border-hover);
+  background: var(--oc-component-surface-hover);
+  box-shadow: var(--oc-component-shadow-hover);
+  transform: translateY(-1px);
+}
+
+.oc-card-interactive:focus-visible {
+  outline: 2px solid var(--oc-focus-ring);
+  outline-offset: 3px;
+}
+
+.oc-card-interactive:active {
+  transform: translateY(0) scale(0.995);
+}
+
+.oc-action {
+  display: inline-flex;
+  min-height: 2.5rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--oc-space-2);
+  padding: var(--oc-space-2) var(--oc-space-4);
+  border: 1px solid transparent;
+  border-radius: var(--oc-radius-control);
+  font: inherit;
+  font-size: var(--oc-font-size-base);
+  font-weight: 700;
+  line-height: 1.2;
+  text-decoration: none;
+  touch-action: manipulation;
+  cursor: pointer;
+  transition:
+    background var(--oc-duration-fast) var(--oc-ease-out),
+    border-color var(--oc-duration-fast) var(--oc-ease-out),
+    color var(--oc-duration-fast) var(--oc-ease-out),
+    transform var(--oc-duration-fast) var(--oc-ease-out);
+}
+
+.oc-action:hover {
+  text-decoration: none;
+}
+
+.oc-action:focus-visible {
+  outline: 2px solid var(--oc-focus-ring);
+  outline-offset: 3px;
+}
+
+.oc-action:active:not(:disabled):not([aria-disabled="true"]) {
+  transform: scale(0.98);
+}
+
+.oc-action:disabled,
+.oc-action[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.oc-action[aria-disabled="true"] {
+  pointer-events: none;
+}
+
+.oc-action-primary {
+  border-color: var(--oc-accent-primary);
+  background: var(--oc-accent-primary);
+  color: var(--oc-text-on-accent);
+}
+
+.oc-action-primary:hover {
+  border-color: var(--oc-accent-primary-hover);
+  background: var(--oc-accent-primary-hover);
+  color: var(--oc-text-on-accent);
+}
+
+.oc-action-secondary {
+  border-color: var(--oc-border-accent);
+  background: var(--oc-surface-accent-soft);
+  color: var(--oc-accent-primary);
+}
+
+.oc-action-secondary:hover {
+  border-color: var(--oc-accent-primary);
+  background: color-mix(in srgb, var(--oc-surface-accent-soft) 72%, var(--oc-accent-primary));
+  color: var(--oc-text-primary);
+}
+
+html[data-theme="light"] .oc-action-secondary,
+html[data-theme-resolved="light"] .oc-action-secondary {
+  border-color: var(--oc-border-strong);
+  background: var(--oc-bg-elevated);
+  color: var(--oc-text-primary);
+}
+
+html[data-theme="light"] .oc-action-secondary:hover,
+html[data-theme-resolved="light"] .oc-action-secondary:hover {
+  border-color: var(--oc-border-strong);
+  background: var(--oc-surface-interactive-hover);
+  color: var(--oc-text-primary);
+}
+
+.oc-action-ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--oc-text-secondary);
+}
+
+.oc-action-ghost:hover {
+  background: var(--oc-surface-interactive);
+  color: var(--oc-text-primary);
+}
+
+.oc-action-icon {
+  width: 2.5rem;
+  padding: 0;
+}
+
+.oc-segmented {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  gap: var(--oc-space-1);
+  overflow-x: auto;
+  padding: var(--oc-space-1);
+  border: 1px solid var(--oc-border-subtle);
+  border-radius: var(--oc-radius-control);
+  background: var(--oc-surface-card);
+}
+
+.oc-segmented-item {
+  display: inline-flex;
+  min-height: 2rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--oc-space-2);
+  padding: var(--oc-space-1) var(--oc-space-3);
+  border: 0;
+  border-radius: var(--oc-radius-inset);
+  background: transparent;
+  color: var(--oc-text-secondary);
+  font: inherit;
+  font-size: var(--oc-font-size-base);
+  font-weight: 650;
+  line-height: 1;
+  white-space: nowrap;
+  touch-action: manipulation;
+  cursor: pointer;
+  transition:
+    background var(--oc-duration-fast) var(--oc-ease-out),
+    color var(--oc-duration-fast) var(--oc-ease-out),
+    transform var(--oc-duration-fast) var(--oc-ease-out);
+}
+
+.oc-segmented-item:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.oc-segmented-item:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.oc-segmented-item:hover {
+  color: var(--oc-text-primary);
+}
+
+.oc-segmented-item[aria-selected="true"],
+.oc-segmented-item[aria-pressed="true"],
+.oc-segmented-item.is-active {
+  background: var(--oc-surface-interactive-hover);
+  color: var(--oc-text-primary);
+}
+
+.oc-segmented-item:focus-visible {
+  outline: 2px solid var(--oc-focus-ring);
+  outline-offset: 2px;
+}
+
+.oc-pill {
+  display: inline-flex;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 1.75rem;
+  align-items: center;
+  gap: var(--oc-space-2);
+  padding: var(--oc-space-1) var(--oc-space-3);
+  border: 1px solid var(--oc-border-subtle);
+  border-radius: var(--oc-radius-control);
+  background: var(--oc-surface-card);
+  color: var(--oc-text-secondary);
+  font-size: var(--oc-font-size-xs);
+  font-weight: 650;
+  line-height: 1;
+  overflow-wrap: anywhere;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .oc-card-interactive {
+    transition: none;
+  }
+
+  .oc-card-interactive:hover,
+  .oc-card-interactive:focus-visible,
+  .oc-card-interactive:active {
+    transform: none;
+  }
+}
+
+@media (max-width: 42rem) {
+  .oc-section-header {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .oc-hero-title {
+    font-size: clamp(2rem, 11vw, 2.75rem);
+  }
+}

--- a/docs/assets/carapace/themes.css
+++ b/docs/assets/carapace/themes.css
@@ -1,0 +1,165 @@
+:root,
+html[data-theme="dark"] {
+  color-scheme: dark;
+
+  --oc-bg-page: var(--oc-palette-ink-950);
+  --oc-bg-surface: var(--oc-palette-ink-900);
+  --oc-bg-elevated: var(--oc-palette-ink-850);
+  --oc-bg-recessed: color-mix(in oklch, var(--oc-bg-page) 86%, oklch(0 0 0));
+  --oc-bg-contrast: var(--oc-text-primary);
+
+  --oc-accent-primary: var(--oc-palette-coral-dark-bright);
+  --oc-accent-primary-hover: var(--oc-palette-coral-dark-mid);
+  --oc-accent-primary-deep: var(--oc-palette-coral-dark-deep);
+  --oc-accent-secondary: var(--oc-palette-sea-dark-bright);
+  --oc-accent-secondary-deep: var(--oc-palette-sea-dark-mid);
+
+  --oc-text-primary: var(--oc-palette-ink-50);
+  --oc-text-secondary: var(--oc-palette-ink-300);
+  --oc-text-muted: var(--oc-palette-ink-500);
+  --oc-text-inactive: color-mix(in oklch, var(--oc-text-muted) 62%, transparent);
+  --oc-text-inverse: var(--oc-bg-page);
+  --oc-text-link: var(--oc-accent-primary);
+  --oc-text-on-accent: var(--oc-palette-ink-950);
+
+  --oc-border-subtle: rgb(154 154 162 / 0.18);
+  --oc-border-strong: color-mix(in oklch, var(--oc-text-primary) 32%, transparent);
+  --oc-border-accent: rgb(245 101 74 / 0.4);
+
+  --oc-surface-card: rgb(25 25 28 / 0.72);
+  --oc-surface-card-strong: rgb(25 25 28 / 0.9);
+  --oc-surface-overlay: rgb(0 0 0 / 0.3);
+  --oc-surface-interactive: rgb(237 237 237 / 0.08);
+  --oc-surface-interactive-hover: rgb(237 237 237 / 0.16);
+  --oc-control-bg: var(--oc-surface-interactive);
+  --oc-control-bg-hover: var(--oc-surface-interactive-hover);
+  --oc-surface-accent-soft: rgb(245 101 74 / 0.14);
+  --oc-surface-secondary-soft: rgb(79 200 174 / 0.14);
+  --oc-chart-line: rgb(237 237 237 / 0.09);
+  --oc-selection-bg: rgb(245 101 74 / 0.28);
+  --oc-focus-ring: rgb(79 200 174 / 0.72);
+
+  /* Compatibility aliases retained for zero-diff openclaw.ai extraction. */
+  --bg-deep: var(--oc-bg-page);
+  --bg-surface: var(--oc-bg-surface);
+  --bg-elevated: var(--oc-bg-elevated);
+  --coral-bright: var(--oc-accent-primary);
+  --coral-mid: var(--oc-accent-primary-hover);
+  --coral-dark: var(--oc-accent-primary-deep);
+  --cyan-bright: var(--oc-accent-secondary);
+  --cyan-mid: var(--oc-accent-secondary-deep);
+  --cyan-glow: rgb(79 200 174 / 0.35);
+  --text-primary: var(--oc-text-primary);
+  --text-secondary: var(--oc-text-secondary);
+  --text-muted: var(--oc-text-muted);
+  --on-accent: var(--oc-text-on-accent);
+  --border-subtle: var(--oc-border-subtle);
+  --border-accent: var(--oc-border-accent);
+  --surface-card: var(--oc-surface-card);
+  --surface-card-strong: var(--oc-surface-card-strong);
+  --surface-overlay: var(--oc-surface-overlay);
+  --surface-interactive: var(--oc-surface-interactive);
+  --surface-interactive-hover: var(--oc-surface-interactive-hover);
+  --surface-coral-soft: var(--oc-surface-accent-soft);
+  --surface-cyan-soft: var(--oc-surface-secondary-soft);
+  --surface-inset-highlight: rgb(237 237 237 / 0.05);
+  --chart-line: var(--oc-chart-line);
+}
+
+html[data-theme="light"] {
+  color-scheme: light;
+
+  --oc-bg-page: var(--oc-palette-paper-100);
+  --oc-bg-surface: var(--oc-palette-paper-200);
+  --oc-bg-elevated: var(--oc-palette-paper-50);
+  --oc-bg-recessed: color-mix(
+    in oklch,
+    var(--oc-bg-page) 94%,
+    var(--oc-text-primary)
+  );
+  --oc-bg-contrast: var(--oc-text-primary);
+
+  --oc-accent-primary: var(--oc-palette-coral-light-bright);
+  --oc-accent-primary-hover: var(--oc-palette-coral-light-mid);
+  --oc-accent-primary-deep: var(--oc-palette-coral-light-deep);
+  --oc-accent-secondary: var(--oc-palette-sea-light-bright);
+  --oc-accent-secondary-deep: var(--oc-palette-sea-light-mid);
+
+  --oc-text-primary: var(--oc-palette-paper-950);
+  --oc-text-secondary: var(--oc-palette-paper-700);
+  --oc-text-muted: var(--oc-palette-paper-600);
+  --oc-text-inactive: color-mix(in oklch, var(--oc-text-muted) 62%, transparent);
+  --oc-text-inverse: var(--oc-bg-page);
+  --oc-text-link: var(--oc-accent-primary);
+  --oc-text-on-accent: var(--oc-palette-paper-50);
+
+  --oc-border-subtle: rgb(23 23 26 / 0.14);
+  --oc-border-strong: color-mix(in oklch, var(--oc-text-primary) 28%, transparent);
+  --oc-border-accent: rgb(216 74 49 / 0.42);
+
+  --oc-surface-card: rgb(255 255 255 / 0.8);
+  --oc-surface-card-strong: rgb(255 255 255 / 0.95);
+  --oc-surface-overlay: rgb(23 23 26 / 0.08);
+  --oc-surface-interactive: rgb(23 23 26 / 0.07);
+  --oc-surface-interactive-hover: rgb(23 23 26 / 0.14);
+  --oc-control-bg: var(--oc-surface-interactive);
+  --oc-control-bg-hover: var(--oc-surface-interactive-hover);
+  --oc-surface-accent-soft: rgb(216 74 49 / 0.12);
+  --oc-surface-secondary-soft: rgb(20 128 110 / 0.13);
+  --oc-chart-line: rgb(23 23 26 / 0.12);
+  --oc-selection-bg: rgb(216 74 49 / 0.2);
+  --oc-focus-ring: rgb(20 128 110 / 0.58);
+
+  --cyan-glow: rgb(20 128 110 / 0.24);
+  --surface-inset-highlight: rgb(23 23 26 / 0.05);
+}
+
+/* Neutral application palette used by the reference site. Keep this additive
+   to the stable theme contract: the stronger root selectors let consumers
+   import themes/product.css afterward without copying these role overrides. */
+html:root,
+html:root[data-theme="dark"] {
+  --oc-bg-page: oklch(0.135 0 0);
+  --oc-bg-surface: oklch(0.178 0 0);
+  --oc-bg-elevated: oklch(0.205 0 0);
+  --oc-text-primary: oklch(0.985 0 0);
+  --oc-text-secondary: oklch(0.87 0 0);
+  --oc-text-muted: oklch(0.716 0 0);
+  --oc-text-on-accent: oklch(0.135 0 0);
+  --oc-border-subtle: oklch(0.269 0 0);
+  --oc-surface-card: oklch(0.178 0 0 / 0.82);
+  --oc-surface-card-strong: oklch(0.205 0 0 / 0.96);
+  --oc-surface-overlay: oklch(0 0 0 / 0.3);
+  --oc-surface-interactive: oklch(0.178 0 0);
+  --oc-surface-interactive-hover: oklch(0.239 0 0);
+  --oc-control-bg: var(--oc-surface-interactive);
+  --oc-control-bg-hover: var(--oc-surface-interactive-hover);
+  --oc-chart-line: oklch(1 0 0 / 0.1);
+  --oc-focus-ring: oklch(0.935 0 0 / 0.72);
+  --oc-input-bg: oklch(0.205 0 0);
+  --oc-input-focus-border: color-mix(in srgb, var(--oc-text-primary) 62%, transparent);
+  --oc-input-focus-ring: color-mix(in srgb, var(--oc-text-primary) 22%, transparent);
+}
+
+html:root[data-theme="light"] {
+  --oc-bg-page: oklch(0.985 0 0);
+  --oc-bg-surface: oklch(0.97 0 0);
+  --oc-bg-elevated: oklch(1 0 0);
+  --oc-text-primary: oklch(0.205 0 0);
+  --oc-text-secondary: oklch(0.269 0 0);
+  --oc-text-muted: oklch(0.555 0 0);
+  --oc-text-on-accent: oklch(1 0 0);
+  --oc-border-subtle: oklch(0.922 0 0);
+  --oc-surface-card: oklch(1 0 0);
+  --oc-surface-card-strong: oklch(1 0 0);
+  --oc-surface-overlay: oklch(0.205 0 0 / 0.08);
+  --oc-surface-interactive: oklch(0.97 0 0);
+  --oc-surface-interactive-hover: oklch(0.922 0 0);
+  --oc-control-bg: var(--oc-bg-elevated);
+  --oc-control-bg-hover: var(--oc-surface-interactive-hover);
+  --oc-chart-line: oklch(0.205 0 0 / 0.12);
+  --oc-focus-ring: oklch(0.15 0 0 / 0.7);
+  --oc-input-bg: oklch(1 0 0);
+  --oc-input-focus-border: color-mix(in srgb, var(--oc-text-primary) 62%, transparent);
+  --oc-input-focus-ring: color-mix(in srgb, var(--oc-text-primary) 22%, transparent);
+}

--- a/docs/assets/carapace/tokens.css
+++ b/docs/assets/carapace/tokens.css
@@ -1,0 +1,69 @@
+:root {
+  /* Canonical source palette: openclaw.ai at b94b43b. */
+  --oc-palette-ink-950: #101012;
+  --oc-palette-ink-900: #19191c;
+  --oc-palette-ink-850: #202024;
+  --oc-palette-ink-50: #ededed;
+  --oc-palette-ink-300: #bcbcc4;
+  --oc-palette-ink-500: #9a9aa2;
+
+  --oc-palette-paper-50: #ffffff;
+  --oc-palette-paper-100: #f6f5f3;
+  --oc-palette-paper-200: #eceae6;
+  --oc-palette-paper-950: #17171a;
+  --oc-palette-paper-700: #46464e;
+  --oc-palette-paper-600: #63636c;
+
+  --oc-palette-coral-dark-bright: #f5654a;
+  --oc-palette-coral-dark-mid: #e05540;
+  --oc-palette-coral-dark-deep: #b23a28;
+  --oc-palette-coral-light-bright: #d84a31;
+  --oc-palette-coral-light-mid: #c24028;
+  --oc-palette-coral-light-deep: #9c3222;
+
+  --oc-palette-sea-dark-bright: #4fc8ae;
+  --oc-palette-sea-dark-mid: #2fa48d;
+  --oc-palette-sea-light-bright: #14806e;
+  --oc-palette-sea-light-mid: #0f6355;
+
+  --oc-space-1: 0.25rem;
+  --oc-space-2: 0.5rem;
+  --oc-space-3: 0.75rem;
+  --oc-space-4: 1rem;
+  --oc-space-5: 1.5rem;
+  --oc-space-6: 2rem;
+  --oc-space-7: 3rem;
+  --oc-space-8: 4rem;
+
+  --oc-font-size-xs: 0.75rem;
+  --oc-font-size-sm: 0.8125rem;
+  --oc-font-size-base: 0.875rem;
+  --oc-font-size-md: 0.9375rem;
+  --oc-font-size-lg: 1.0625rem;
+  --oc-font-size-xl: 1.25rem;
+  --oc-font-size-2xl: 1.5rem;
+  --oc-font-size-3xl: 2rem;
+
+  --oc-radius-sm: 0.25rem;
+  --oc-radius-md: 0.5rem;
+  --oc-radius-lg: 0.75rem;
+  --oc-radius-xl: 1rem;
+  --oc-radius-full: 999px;
+  --oc-radius-surface: var(--oc-radius-md);
+  --oc-radius-control: var(--oc-radius-md);
+  --oc-radius-inset: var(--oc-radius-sm);
+  --oc-radius-round: var(--oc-radius-full);
+
+  --oc-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.12);
+  --oc-shadow-md: 0 8px 24px -6px rgb(0 0 0 / 0.28);
+  --oc-shadow-lg: 0 24px 48px -12px rgb(0 0 0 / 0.42);
+
+  --oc-duration-fast: 160ms;
+  --oc-duration-ui: 200ms;
+  --oc-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+
+  --oc-control-min-height: 2.75rem;
+
+  --oc-content-max: 75rem;
+  --oc-content-narrow: 48rem;
+}

--- a/docs/assets/carapace/typography.css
+++ b/docs/assets/carapace/typography.css
@@ -1,0 +1,15 @@
+:root {
+  /*
+   * Font binaries are intentionally not distributed. Consumers must load
+   * licensed fonts themselves or use the documented fallback stacks.
+   */
+  --oc-font-display: "Switzer", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --oc-font-body: "Switzer", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --oc-font-serif: "Sentient", Georgia, "Times New Roman", serif;
+  --oc-font-mono: ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, monospace;
+
+  --font-display: var(--oc-font-display);
+  --font-body: var(--oc-font-body);
+  --font-serif: var(--oc-font-serif);
+  --font-mono: var(--oc-font-mono);
+}

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -1,0 +1,1284 @@
+/* ClawScan docs composition. Shared visual primitives come from Carapace v0.6.1. */
+:root {
+  --oc-font-display: "Instrument Sans", "Helvetica Neue", sans-serif;
+  --oc-font-body: "Instrument Sans", "Helvetica Neue", sans-serif;
+  --oc-font-mono: "IBM Plex Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+  --docs-header-height: 3.75rem;
+  --docs-sidebar-width: 15.5rem;
+  --docs-copy: 47rem;
+  --docs-code-bg: var(--oc-palette-ink-950);
+  --docs-code-fg: var(--oc-palette-ink-50);
+  --docs-scan-line: color-mix(in srgb, var(--oc-accent-secondary) 38%, transparent);
+}
+
+html[data-theme="dark"] {
+  --docs-code-bg: var(--oc-bg-recessed);
+  --docs-code-fg: var(--oc-text-primary);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: calc(var(--docs-header-height) + var(--oc-space-5));
+}
+
+body {
+  min-width: 20rem;
+  margin: 0;
+  overflow-x: clip;
+  background: var(--oc-bg-page);
+  color: var(--oc-text-primary);
+  font-family: var(--oc-font-body);
+  font-size: var(--oc-font-size-md);
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+body::before {
+  position: fixed;
+  z-index: -1;
+  inset: var(--docs-header-height) 0 0 var(--docs-sidebar-width);
+  background-image:
+    linear-gradient(to right, var(--oc-chart-line) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--oc-chart-line) 1px, transparent 1px);
+  background-size: 4rem 4rem;
+  mask-image: linear-gradient(to bottom, rgb(0 0 0 / 0.34), transparent 30rem);
+  content: "";
+  pointer-events: none;
+}
+
+::selection {
+  background: var(--oc-selection-bg);
+}
+
+a {
+  color: var(--oc-text-link);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+}
+
+a:hover {
+  color: var(--oc-accent-primary-hover);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  color: inherit;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 100;
+  top: var(--oc-space-2);
+  left: var(--oc-space-2);
+  transform: translateY(-150%);
+}
+
+.skip-link:focus {
+  transform: none;
+}
+
+.topbar {
+  position: fixed;
+  z-index: 30;
+  top: 0;
+  right: 0;
+  left: 0;
+  display: grid;
+  height: var(--docs-header-height);
+  grid-template-columns: var(--docs-sidebar-width) minmax(16rem, 1fr) auto;
+  align-items: stretch;
+  border-bottom: 1px solid var(--oc-border-subtle);
+  background: color-mix(in srgb, var(--oc-bg-page) 92%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.brand {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--oc-space-3);
+  padding: 0 var(--oc-space-4);
+  border-right: 1px solid var(--oc-border-subtle);
+  color: var(--oc-text-primary);
+  font-weight: 750;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+}
+
+.brand:hover {
+  color: var(--oc-text-primary);
+  text-decoration: none;
+}
+
+.brand-mark {
+  width: 1.8rem;
+  height: 1.8rem;
+  flex: 0 0 auto;
+  border-radius: var(--oc-radius-inset);
+}
+
+.brand-product {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.brand-divider,
+.brand-section {
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: var(--oc-font-size-xs);
+  font-weight: 500;
+}
+
+.topbar-center {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--oc-space-4);
+}
+
+.install-command {
+  display: inline-flex;
+  width: min(100%, 31rem);
+  min-height: 2.25rem;
+  align-items: center;
+  gap: var(--oc-space-2);
+  padding: 0 var(--oc-space-3);
+  overflow: hidden;
+  border: 1px solid var(--oc-border-subtle);
+  border-radius: var(--oc-radius-control);
+  background: var(--oc-control-bg);
+  color: var(--oc-text-secondary);
+  cursor: pointer;
+  transition:
+    background var(--oc-duration-fast) var(--oc-ease-out),
+    border-color var(--oc-duration-fast) var(--oc-ease-out);
+}
+
+.install-command:hover {
+  border-color: var(--oc-border-strong);
+  background: var(--oc-control-bg-hover);
+}
+
+.install-command:focus-visible,
+.icon-button:focus-visible,
+.nav-toggle:focus-visible,
+.search input:focus-visible {
+  outline: 2px solid var(--oc-focus-ring);
+  outline-offset: 2px;
+}
+
+.install-prompt {
+  color: var(--oc-accent-secondary);
+  font-family: var(--oc-font-mono);
+}
+
+.install-command code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--oc-text-primary);
+  font-family: var(--oc-font-mono);
+  font-size: var(--oc-font-size-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.install-copy {
+  margin-left: auto;
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: 0.64rem;
+  text-transform: uppercase;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--oc-space-1);
+  padding: 0 var(--oc-space-3);
+  border-left: 1px solid var(--oc-border-subtle);
+}
+
+.source-link {
+  min-height: 2.25rem;
+}
+
+.source-link svg,
+.icon-button svg,
+.nav-toggle svg,
+.home-card svg {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+}
+
+.icon-button,
+.nav-toggle {
+  display: inline-grid;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--oc-radius-control);
+  background: transparent;
+  color: var(--oc-text-secondary);
+  cursor: pointer;
+  place-items: center;
+}
+
+.icon-button:hover,
+.nav-toggle:hover {
+  background: var(--oc-surface-interactive);
+  color: var(--oc-text-primary);
+}
+
+.theme-icon-sun,
+.nav-toggle {
+  display: none;
+}
+
+html[data-theme="dark"] .theme-icon-moon {
+  display: none;
+}
+
+html[data-theme="dark"] .theme-icon-sun {
+  display: block;
+}
+
+.sidebar {
+  position: fixed;
+  z-index: 20;
+  top: var(--docs-header-height);
+  bottom: 0;
+  left: 0;
+  display: flex;
+  width: var(--docs-sidebar-width);
+  flex-direction: column;
+  overflow: auto;
+  border-right: 1px solid var(--oc-border-subtle);
+  background: var(--oc-bg-page);
+}
+
+.sidebar-inner {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  padding: var(--oc-space-5) var(--oc-space-3) var(--oc-space-4);
+}
+
+.sidebar-kicker {
+  margin: 0 var(--oc-space-2) var(--oc-space-3);
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.search {
+  position: relative;
+  display: block;
+  margin-bottom: var(--oc-space-5);
+}
+
+.search svg {
+  position: absolute;
+  top: 50%;
+  left: var(--oc-space-3);
+  width: 0.95rem;
+  height: 0.95rem;
+  transform: translateY(-50%);
+  color: var(--oc-text-muted);
+  pointer-events: none;
+}
+
+.search input {
+  width: 100%;
+  min-height: 2.35rem;
+  padding: 0 var(--oc-space-3) 0 2.25rem;
+  border: 1px solid var(--oc-border-subtle);
+  border-radius: var(--oc-radius-control);
+  background: var(--oc-control-bg);
+  color: var(--oc-text-primary);
+  font-size: var(--oc-font-size-sm);
+}
+
+.search input::placeholder {
+  color: var(--oc-text-muted);
+}
+
+.docs-nav section + section {
+  margin-top: var(--oc-space-5);
+}
+
+.docs-nav h2 {
+  margin: 0 var(--oc-space-2) var(--oc-space-2);
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.nav-link {
+  position: relative;
+  display: flex;
+  min-height: 2.1rem;
+  align-items: center;
+  padding: 0 var(--oc-space-3);
+  border-radius: var(--oc-radius-control);
+  color: var(--oc-text-secondary);
+  font-size: var(--oc-font-size-sm);
+  font-weight: 580;
+  text-decoration: none;
+}
+
+.nav-link[hidden] {
+  display: none;
+}
+
+.nav-link:hover {
+  background: var(--oc-surface-interactive);
+  color: var(--oc-text-primary);
+  text-decoration: none;
+}
+
+.nav-link.current {
+  background: var(--oc-surface-interactive-hover);
+  color: var(--oc-text-primary);
+  font-weight: 700;
+}
+
+.nav-link.current::before {
+  position: absolute;
+  left: 0;
+  width: 2px;
+  height: 1rem;
+  background: var(--oc-accent-primary);
+  content: "";
+}
+
+.sidebar-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--oc-space-2);
+  margin-top: auto;
+  padding: var(--oc-space-5) var(--oc-space-2) 0;
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: 0.66rem;
+}
+
+.sidebar-footer a {
+  color: inherit;
+}
+
+.sidebar-overlay {
+  display: none;
+}
+
+.sidebar-overlay[hidden] {
+  display: none;
+}
+
+.site-main {
+  min-height: 100vh;
+  margin-left: var(--docs-sidebar-width);
+  padding-top: var(--docs-header-height);
+}
+
+.page-frame {
+  width: min(100%, 90rem);
+  margin: 0 auto;
+  padding: clamp(2rem, 4vw, 4.5rem) clamp(1.5rem, 4.5vw, 4.5rem) 6rem;
+}
+
+.page-heading {
+  max-width: var(--docs-copy);
+  margin-bottom: var(--oc-space-7);
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: var(--oc-space-2);
+  margin-bottom: var(--oc-space-4);
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: var(--oc-font-size-xs);
+}
+
+.breadcrumb a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  color: var(--oc-text-primary);
+}
+
+.page-heading h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 5vw, 4.75rem);
+  font-weight: 720;
+  letter-spacing: -0.055em;
+  line-height: 0.98;
+  text-wrap: balance;
+}
+
+.doc-grid {
+  display: grid;
+  grid-template-columns: minmax(0, var(--docs-copy)) 12rem;
+  gap: clamp(3rem, 7vw, 7rem);
+  align-items: start;
+}
+
+.doc {
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
+.doc > h1:first-child {
+  display: none;
+}
+
+.doc h2,
+.doc h3 {
+  color: var(--oc-text-primary);
+  font-family: var(--oc-font-display);
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+
+.doc h2 {
+  margin: 3.75rem 0 var(--oc-space-3);
+  padding-top: var(--oc-space-5);
+  border-top: 1px solid var(--oc-border-subtle);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+  line-height: 1.12;
+}
+
+.doc h3 {
+  margin: var(--oc-space-7) 0 var(--oc-space-2);
+  font-size: var(--oc-font-size-xl);
+  font-weight: 680;
+  line-height: 1.25;
+}
+
+.doc h2:first-of-type {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
+
+.doc p,
+.doc ul,
+.doc ol,
+.doc pre,
+.doc blockquote,
+.doc details,
+.table-scroll {
+  margin: 0 0 var(--oc-space-5);
+}
+
+.doc p,
+.doc li {
+  color: var(--oc-text-secondary);
+}
+
+.doc p {
+  text-wrap: pretty;
+}
+
+.doc ul,
+.doc ol {
+  padding-left: 1.35rem;
+}
+
+.doc li + li {
+  margin-top: var(--oc-space-2);
+}
+
+.doc strong {
+  color: var(--oc-text-primary);
+  font-weight: 700;
+}
+
+code {
+  font-family: var(--oc-font-mono);
+}
+
+.doc :not(pre) > code {
+  padding: 0.12em 0.35em;
+  border: 1px solid var(--oc-border-subtle);
+  border-radius: var(--oc-radius-inset);
+  background: var(--oc-surface-interactive);
+  color: var(--oc-text-primary);
+  font-size: 0.86em;
+}
+
+.doc pre {
+  position: relative;
+  overflow-x: auto;
+  padding: var(--oc-space-5);
+  border: 1px solid color-mix(in srgb, var(--docs-code-fg) 16%, transparent);
+  border-radius: var(--oc-radius-surface);
+  background:
+    linear-gradient(90deg, var(--docs-scan-line), transparent 28%),
+    var(--docs-code-bg);
+  box-shadow: var(--oc-shadow-sm);
+  color: var(--docs-code-fg);
+  font-size: var(--oc-font-size-sm);
+  line-height: 1.65;
+}
+
+.doc pre::before {
+  display: block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-bottom: var(--oc-space-4);
+  border-radius: var(--oc-radius-round);
+  background: var(--oc-accent-primary);
+  box-shadow:
+    0.8rem 0 var(--oc-accent-secondary),
+    1.6rem 0 color-mix(in srgb, var(--docs-code-fg) 40%, transparent);
+  content: "";
+}
+
+.doc pre code {
+  display: block;
+  min-width: max-content;
+  color: inherit;
+  white-space: pre;
+}
+
+.copy {
+  position: absolute;
+  top: var(--oc-space-3);
+  right: var(--oc-space-3);
+  min-height: 1.75rem;
+  padding: 0 var(--oc-space-2);
+  border: 1px solid color-mix(in srgb, var(--docs-code-fg) 18%, transparent);
+  border-radius: var(--oc-radius-control);
+  background: color-mix(in srgb, var(--docs-code-fg) 8%, transparent);
+  color: color-mix(in srgb, var(--docs-code-fg) 72%, transparent);
+  cursor: pointer;
+  font-family: var(--oc-font-mono);
+  font-size: 0.65rem;
+  font-weight: 600;
+  opacity: 0;
+  text-transform: uppercase;
+  transition: opacity var(--oc-duration-fast) var(--oc-ease-out);
+}
+
+.doc pre:hover .copy,
+.copy:focus-visible,
+.copy.copied {
+  opacity: 1;
+}
+
+.copy.copied {
+  border-color: var(--oc-accent-secondary);
+  color: var(--oc-accent-secondary);
+}
+
+.table-scroll {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--oc-border-subtle);
+  border-radius: var(--oc-radius-surface);
+  background: var(--oc-surface-card);
+}
+
+.table-scroll:focus-visible {
+  outline: 2px solid var(--oc-focus-ring);
+  outline-offset: 2px;
+}
+
+.doc table {
+  width: 100%;
+  min-width: 36rem;
+  border-collapse: collapse;
+  font-size: var(--oc-font-size-sm);
+}
+
+.doc th,
+.doc td {
+  padding: var(--oc-space-3) var(--oc-space-4);
+  border-bottom: 1px solid var(--oc-border-subtle);
+  color: var(--oc-text-secondary);
+  text-align: left;
+  vertical-align: top;
+}
+
+.doc th {
+  background: var(--oc-bg-surface);
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.doc tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.doc tbody tr:hover {
+  background: var(--oc-surface-interactive);
+}
+
+.doc blockquote {
+  padding: var(--oc-space-4) var(--oc-space-5);
+  border-left: 2px solid var(--oc-accent-primary);
+  background: var(--oc-surface-accent-soft);
+}
+
+.doc blockquote p:last-child {
+  margin-bottom: 0;
+  color: var(--oc-text-primary);
+}
+
+.doc details {
+  overflow: hidden;
+  border: 1px solid var(--oc-border-subtle);
+  border-radius: var(--oc-radius-surface);
+  background: var(--oc-surface-card);
+}
+
+.doc summary {
+  padding: var(--oc-space-3) var(--oc-space-4);
+  color: var(--oc-text-primary);
+  cursor: pointer;
+  font-family: var(--oc-font-mono);
+  font-size: var(--oc-font-size-xs);
+  font-weight: 600;
+}
+
+.doc details pre {
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--oc-border-subtle);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.toc {
+  position: sticky;
+  top: calc(var(--docs-header-height) + var(--oc-space-6));
+  max-height: calc(100vh - var(--docs-header-height) - var(--oc-space-7));
+  overflow: auto;
+  padding-left: var(--oc-space-4);
+  border-left: 1px solid var(--oc-border-subtle);
+}
+
+.toc h2 {
+  margin: 0 0 var(--oc-space-3);
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.toc a {
+  position: relative;
+  display: block;
+  padding: var(--oc-space-1) 0;
+  color: var(--oc-text-muted);
+  font-size: var(--oc-font-size-xs);
+  line-height: 1.45;
+  text-decoration: none;
+}
+
+.toc a:hover,
+.toc a.active {
+  color: var(--oc-text-primary);
+}
+
+.toc a.active::before {
+  position: absolute;
+  top: 0.45rem;
+  left: calc(-1rem - 1px);
+  width: 2px;
+  height: 0.85rem;
+  background: var(--oc-accent-primary);
+  content: "";
+}
+
+.toc-l3 {
+  padding-left: var(--oc-space-3) !important;
+}
+
+.page-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--oc-space-3);
+  margin-top: var(--oc-space-8);
+  padding-top: var(--oc-space-5);
+  border-top: 1px solid var(--oc-border-subtle);
+}
+
+.page-nav a {
+  display: grid;
+  min-height: 5.5rem;
+  align-content: center;
+  padding: var(--oc-space-4);
+  color: var(--oc-text-primary);
+  text-decoration: none;
+}
+
+.page-nav a:hover {
+  border-color: var(--oc-border-strong);
+  background: var(--oc-surface-interactive);
+}
+
+.page-nav small {
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+}
+
+.page-nav span {
+  font-weight: 680;
+}
+
+.page-nav-next {
+  grid-column: 2;
+  text-align: right;
+}
+
+.home .page-frame {
+  padding-top: 0;
+}
+
+.home-hero {
+  position: relative;
+  display: grid;
+  min-height: min(46rem, calc(100vh - var(--docs-header-height)));
+  grid-template-columns: minmax(0, 1.08fr) minmax(20rem, 0.92fr);
+  align-items: center;
+  gap: clamp(2.5rem, 7vw, 7rem);
+  overflow: clip;
+  overflow-clip-margin: 3rem;
+  padding: clamp(4rem, 9vw, 8rem) 0;
+  border-bottom: 1px solid var(--oc-border-subtle);
+}
+
+.home-hero::after {
+  position: absolute;
+  z-index: -1;
+  top: 6%;
+  right: -4%;
+  width: min(45vw, 36rem);
+  aspect-ratio: 1;
+  background: url("clawscan-logo.svg") center / contain no-repeat;
+  filter: grayscale(1);
+  opacity: 0.035;
+  content: "";
+  transform: rotate(-7deg);
+}
+
+.home-hero-copy {
+  position: relative;
+  z-index: 1;
+}
+
+.home-hero h1 {
+  max-width: 13ch;
+  margin: var(--oc-space-4) 0 var(--oc-space-5);
+  font-size: clamp(3.25rem, 7.4vw, 7.75rem);
+  font-weight: 740;
+  letter-spacing: -0.07em;
+  line-height: 0.87;
+  text-wrap: balance;
+}
+
+.home-hero h1 span {
+  color: var(--oc-accent-primary);
+}
+
+.home-lede {
+  max-width: 38rem;
+  margin: 0;
+  color: var(--oc-text-secondary);
+  font-size: clamp(1rem, 1.8vw, 1.2rem);
+  line-height: 1.6;
+  text-wrap: pretty;
+}
+
+.home-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--oc-space-3);
+  margin-top: var(--oc-space-6);
+}
+
+.home-proof {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--oc-space-3) var(--oc-space-5);
+  margin-top: var(--oc-space-6);
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: 0.68rem;
+}
+
+.home-proof span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--oc-space-2);
+}
+
+.home-proof i {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: var(--oc-radius-round);
+  background: var(--oc-accent-secondary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--oc-accent-secondary) 14%, transparent);
+}
+
+.scan-console {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--docs-code-fg) 14%, transparent);
+  border-radius: var(--oc-radius-surface);
+  background: var(--docs-code-bg);
+  box-shadow: var(--oc-shadow-lg);
+  color: var(--docs-code-fg);
+  transform: rotate(1.5deg);
+  animation: console-in 600ms var(--oc-ease-out) both;
+}
+
+.scan-console::before {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(to bottom, transparent 49%, rgb(255 255 255 / 0.025) 50%);
+  background-size: 100% 4px;
+  content: "";
+  pointer-events: none;
+}
+
+.scan-console-head,
+.scan-console-row,
+.scan-console-command,
+.scan-console-result {
+  position: relative;
+  z-index: 1;
+}
+
+.scan-console-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--oc-space-3) var(--oc-space-4);
+  border-bottom: 1px solid color-mix(in srgb, var(--docs-code-fg) 12%, transparent);
+  color: color-mix(in srgb, var(--docs-code-fg) 55%, transparent);
+  font-family: var(--oc-font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.window-dots {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.window-dots i {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: var(--oc-radius-round);
+  background: var(--oc-accent-primary);
+}
+
+.window-dots i:nth-child(2) {
+  background: var(--oc-accent-secondary);
+}
+
+.window-dots i:nth-child(3) {
+  background: color-mix(in srgb, var(--docs-code-fg) 40%, transparent);
+}
+
+.scan-console-command {
+  padding: var(--oc-space-5) var(--oc-space-5) var(--oc-space-4);
+  border-bottom: 1px solid color-mix(in srgb, var(--docs-code-fg) 10%, transparent);
+  color: var(--docs-code-fg);
+  font-family: var(--oc-font-mono);
+  font-size: clamp(0.72rem, 1.2vw, 0.82rem);
+  line-height: 1.65;
+}
+
+.scan-console-command b {
+  color: var(--oc-accent-secondary);
+  font-weight: 500;
+}
+
+.scan-console-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--oc-space-3);
+  padding: var(--oc-space-3) var(--oc-space-5);
+  border-bottom: 1px solid color-mix(in srgb, var(--docs-code-fg) 8%, transparent);
+  font-family: var(--oc-font-mono);
+  font-size: 0.72rem;
+}
+
+.scan-console-row span {
+  color: color-mix(in srgb, var(--docs-code-fg) 68%, transparent);
+}
+
+.scan-console-row strong {
+  color: var(--oc-accent-secondary);
+  font-weight: 500;
+}
+
+.scan-console-result {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.scan-console-result div {
+  padding: var(--oc-space-4);
+  border-right: 1px solid color-mix(in srgb, var(--docs-code-fg) 8%, transparent);
+}
+
+.scan-console-result div:last-child {
+  border-right: 0;
+}
+
+.scan-console-result small,
+.scan-console-result strong {
+  display: block;
+  font-family: var(--oc-font-mono);
+}
+
+.scan-console-result small {
+  color: color-mix(in srgb, var(--docs-code-fg) 45%, transparent);
+  font-size: 0.58rem;
+  text-transform: uppercase;
+}
+
+.scan-console-result strong {
+  margin-top: var(--oc-space-1);
+  color: var(--docs-code-fg);
+  font-size: 1rem;
+}
+
+.pipeline {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin: 0 0 var(--oc-space-7);
+  border: 1px solid var(--oc-border-subtle);
+  border-radius: var(--oc-radius-surface);
+  background: var(--oc-surface-card);
+}
+
+.pipeline-step {
+  position: relative;
+  padding: var(--oc-space-4);
+  border-right: 1px solid var(--oc-border-subtle);
+}
+
+.pipeline-step:last-child {
+  border-right: 0;
+}
+
+.pipeline-step:not(:last-child)::after {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  right: -0.42rem;
+  display: grid;
+  width: 0.8rem;
+  height: 0.8rem;
+  border: 1px solid var(--oc-border-subtle);
+  border-radius: var(--oc-radius-round);
+  background: var(--oc-bg-page);
+  color: var(--oc-text-muted);
+  content: "›";
+  font-family: var(--oc-font-mono);
+  font-size: 0.65rem;
+  line-height: 1;
+  place-items: center;
+  transform: translateY(-50%);
+}
+
+.pipeline-step small,
+.pipeline-step strong {
+  display: block;
+}
+
+.pipeline-step small {
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-mono);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+}
+
+.pipeline-step strong {
+  margin-top: var(--oc-space-1);
+  font-size: var(--oc-font-size-sm);
+}
+
+.home-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--oc-space-3);
+  margin: var(--oc-space-7) 0 var(--oc-space-8);
+}
+
+.home-card {
+  display: grid;
+  min-height: 10rem;
+  grid-template-columns: 1fr auto;
+  align-content: space-between;
+  padding: var(--oc-space-5);
+  color: var(--oc-text-primary);
+  text-decoration: none;
+}
+
+.home-card:hover {
+  color: var(--oc-text-primary);
+  text-decoration: none;
+}
+
+.home-card small {
+  color: var(--oc-accent-primary);
+  font-family: var(--oc-font-mono);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+}
+
+.home-card strong {
+  align-self: end;
+  font-size: var(--oc-font-size-lg);
+  letter-spacing: -0.02em;
+}
+
+.home-card svg {
+  color: var(--oc-text-muted);
+}
+
+.home .doc > p:nth-of-type(-n + 2) {
+  display: none;
+}
+
+@keyframes console-in {
+  from {
+    opacity: 0;
+    transform: translateY(1.25rem) rotate(3deg);
+  }
+}
+
+@media (max-width: 74rem) {
+  .doc-grid {
+    grid-template-columns: minmax(0, var(--docs-copy));
+  }
+
+  .toc {
+    display: none;
+  }
+}
+
+@media (max-width: 64rem) {
+  .topbar {
+    grid-template-columns: var(--docs-sidebar-width) minmax(0, 1fr) auto;
+  }
+
+  .source-link span {
+    display: none;
+  }
+
+  .home-hero {
+    min-height: auto;
+    grid-template-columns: 1fr;
+    padding: 5rem 0;
+  }
+
+  .home-hero h1 {
+    max-width: 11ch;
+  }
+
+  .scan-console {
+    width: min(100%, 38rem);
+    transform: none;
+  }
+}
+
+@media (max-width: 52rem) {
+  body::before {
+    left: 0;
+  }
+
+  .topbar {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .brand {
+    border-right: 0;
+  }
+
+  .topbar-center {
+    display: none;
+  }
+
+  .nav-toggle {
+    display: inline-grid;
+  }
+
+  .sidebar {
+    width: min(20rem, calc(100vw - 3rem));
+    transform: translateX(-102%);
+    box-shadow: var(--oc-shadow-lg);
+    transition: transform var(--oc-duration-ui) var(--oc-ease-out);
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  .sidebar-overlay {
+    position: fixed;
+    z-index: 10;
+    inset: var(--docs-header-height) 0 0;
+    display: block;
+    background: var(--oc-surface-overlay);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--oc-duration-ui) var(--oc-ease-out);
+  }
+
+  .sidebar-overlay.open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .site-main {
+    margin-left: 0;
+  }
+
+  .page-frame {
+    padding: var(--oc-space-7) var(--oc-space-5) var(--oc-space-8);
+  }
+
+  .home .page-frame {
+    padding-top: 0;
+  }
+
+  .home-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 36rem) {
+  .brand-section,
+  .brand-divider,
+  .source-link {
+    display: none;
+  }
+
+  .topbar-actions {
+    border-left: 0;
+  }
+
+  .page-frame {
+    padding-right: var(--oc-space-4);
+    padding-left: var(--oc-space-4);
+  }
+
+  .home-hero {
+    gap: var(--oc-space-7);
+    padding: var(--oc-space-8) 0;
+  }
+
+  .home-hero h1 {
+    font-size: clamp(3rem, 16vw, 4.75rem);
+  }
+
+  .home-actions {
+    display: grid;
+  }
+
+  .home-actions .oc-action {
+    width: 100%;
+  }
+
+  .scan-console-result {
+    grid-template-columns: 1fr;
+  }
+
+  .scan-console-result div {
+    border-right: 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--docs-code-fg) 8%, transparent);
+  }
+
+  .scan-console-result div:last-child {
+    border-bottom: 0;
+  }
+
+  .pipeline {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .pipeline-step:nth-child(2) {
+    border-right: 0;
+  }
+
+  .pipeline-step:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--oc-border-subtle);
+  }
+
+  .pipeline-step:nth-child(2)::after {
+    display: none;
+  }
+
+  .doc pre {
+    margin-right: calc(-1 * var(--oc-space-4));
+    margin-left: calc(-1 * var(--oc-space-4));
+    border-right: 0;
+    border-left: 0;
+    border-radius: 0;
+  }
+
+  .page-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .page-nav-next {
+    grid-column: 1;
+    text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .scan-console {
+    animation: none;
+  }
+
+  .sidebar,
+  .sidebar-overlay {
+    transition: none;
+  }
+}

--- a/docs/assets/site.js
+++ b/docs/assets/site.js
@@ -1,0 +1,188 @@
+const root = document.documentElement;
+const sidebar = document.querySelector('.sidebar');
+const overlay = document.querySelector('.sidebar-overlay');
+const menuButton = document.querySelector('.nav-toggle');
+const mobileNav = window.matchMedia('(max-width: 52rem)');
+
+function readStoredTheme() {
+  try {
+    return localStorage.getItem('clawscan-theme');
+  } catch {
+    return null;
+  }
+}
+
+function storeTheme(theme) {
+  try {
+    localStorage.setItem('clawscan-theme', theme);
+  } catch {
+    // Theme persistence is optional in privacy-restricted browsing modes.
+  }
+}
+
+function applyTheme(theme) {
+  root.dataset.theme = theme;
+  document.querySelectorAll('[data-theme-toggle]').forEach((button) => {
+    button.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+    button.setAttribute(
+      'aria-label',
+      theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme',
+    );
+  });
+}
+
+applyTheme(root.dataset.theme === 'dark' ? 'dark' : 'light');
+
+document.querySelectorAll('[data-theme-toggle]').forEach((button) => {
+  button.addEventListener('click', () => {
+    const nextTheme = root.dataset.theme === 'dark' ? 'light' : 'dark';
+    applyTheme(nextTheme);
+    storeTheme(nextTheme);
+  });
+});
+
+const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+const onSystemThemeChange = (event) => {
+  if (!readStoredTheme()) {
+    applyTheme(event.matches ? 'dark' : 'light');
+  }
+};
+
+if (systemTheme.addEventListener) {
+  systemTheme.addEventListener('change', onSystemThemeChange);
+} else {
+  systemTheme.addListener?.(onSystemThemeChange);
+}
+
+function setNavigationOpen(open) {
+  if (!sidebar || !overlay || !menuButton) {
+    return;
+  }
+  const focusWasInSidebar = sidebar.contains(document.activeElement);
+  const sidebarIsHidden = mobileNav.matches && !open;
+  sidebar.classList.toggle('open', open);
+  overlay.classList.toggle('open', open);
+  overlay.hidden = !open;
+  menuButton.setAttribute('aria-expanded', open ? 'true' : 'false');
+  sidebar.toggleAttribute('inert', sidebarIsHidden);
+  if (sidebarIsHidden) {
+    sidebar.setAttribute('aria-hidden', 'true');
+  } else {
+    sidebar.removeAttribute('aria-hidden');
+  }
+  document.body.style.overflow = mobileNav.matches && open ? 'hidden' : '';
+  if (sidebarIsHidden && focusWasInSidebar) {
+    menuButton.focus();
+  }
+}
+
+setNavigationOpen(false);
+menuButton?.addEventListener('click', () => {
+  setNavigationOpen(!sidebar?.classList.contains('open'));
+});
+overlay?.addEventListener('click', () => setNavigationOpen(false));
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    setNavigationOpen(false);
+  }
+});
+
+const onViewportChange = () => setNavigationOpen(false);
+if (mobileNav.addEventListener) {
+  mobileNav.addEventListener('change', onViewportChange);
+} else {
+  mobileNav.addListener?.(onViewportChange);
+}
+
+const searchInput = document.getElementById('doc-search');
+searchInput?.addEventListener('input', () => {
+  const query = searchInput.value.trim().toLowerCase();
+  document.querySelectorAll('.docs-nav section').forEach((section) => {
+    let hasMatch = false;
+    section.querySelectorAll('.nav-link').forEach((link) => {
+      const matches = !query || link.textContent.toLowerCase().includes(query);
+      link.hidden = !matches;
+      hasMatch ||= matches;
+    });
+    section.hidden = !hasMatch;
+  });
+});
+
+document.addEventListener('keydown', (event) => {
+  const target = event.target;
+  const isTyping = target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
+  if (event.key === '/' && !isTyping && searchInput) {
+    event.preventDefault();
+    if (mobileNav.matches) {
+      setNavigationOpen(true);
+    }
+    searchInput.focus();
+  }
+});
+
+async function copyText(button, text) {
+  const idleLabel = button.dataset.idleLabel || button.textContent;
+  try {
+    await navigator.clipboard.writeText(text);
+    button.textContent = 'Copied';
+    button.classList.add('copied');
+  } catch {
+    button.textContent = 'Copy failed';
+  }
+  window.setTimeout(() => {
+    button.textContent = idleLabel;
+    button.classList.remove('copied');
+  }, 1500);
+}
+
+document.querySelectorAll('.doc pre').forEach((pre) => {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'copy';
+  button.textContent = 'Copy';
+  button.dataset.idleLabel = 'Copy';
+  button.setAttribute('aria-label', 'Copy code');
+  button.addEventListener('click', () => {
+    copyText(button, pre.querySelector('code')?.textContent ?? '');
+  });
+  pre.appendChild(button);
+});
+
+document.querySelectorAll('[data-copy-install]').forEach((button) => {
+  const label = button.querySelector('.install-copy');
+  if (!label) {
+    return;
+  }
+  label.dataset.idleLabel = 'Copy';
+  button.addEventListener('click', () => {
+    copyText(label, 'npm install -g @openclaw/clawscan');
+  });
+});
+
+const tocLinks = document.querySelectorAll('.toc a');
+if (tocLinks.length && 'IntersectionObserver' in window) {
+  const linksByHeading = new Map();
+  tocLinks.forEach((link) => {
+    const heading = document.getElementById(link.hash.slice(1));
+    if (heading) {
+      linksByHeading.set(heading, link);
+    }
+  });
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      const visible = entries
+        .filter((entry) => entry.isIntersecting)
+        .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+      const activeLink = visible.length ? linksByHeading.get(visible[0].target) : null;
+      if (!activeLink) {
+        return;
+      }
+      tocLinks.forEach((link) => link.classList.toggle('active', link === activeLink));
+    },
+    { rootMargin: '-18% 0px -68% 0px', threshold: 0 },
+  );
+
+  linksByHeading.forEach((_link, heading) => observer.observe(heading));
+}

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -7,8 +7,6 @@ const docsDir = path.join(root, 'docs');
 const assetsDir = path.join(docsDir, 'assets');
 const outDir = path.join(root, 'dist', 'docs-site');
 const outAssetsDir = path.join(outDir, 'assets');
-const assets = ['clawscan-logo.svg', 'clawscan-logo.png', 'clawscan-banner.svg', 'clawscan-banner.png'];
-
 const pages = [
   ['index.md', 'Introduction'],
   ['scanners.md', 'Scanners'],
@@ -20,665 +18,14 @@ const pages = [
 
 const navSections = [
   ['Start', ['index.md']],
-  ['Run', ['scanners.md', 'profiles.md', 'judge.md', 'sandbox.md', 'benchmarks.md']],
+  ['Workflow', ['scanners.md', 'profiles.md', 'judge.md', 'sandbox.md']],
+  ['Evaluate', ['benchmarks.md']],
 ];
-
-let css = `
-:root {
-  color-scheme: light dark;
-  --bg: #f8fafc;
-  --fg: #152033;
-  --muted: #5d6a7e;
-  --line: #d9e1ec;
-  --panel: #ffffff;
-  --accent: #0969da;
-  --code: #eef3f8;
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0e1117;
-    --fg: #e6edf3;
-    --muted: #98a6b8;
-    --line: #2d3746;
-    --panel: #151b23;
-    --accent: #58a6ff;
-    --code: #1f2937;
-  }
-}
-* { box-sizing: border-box; }
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--fg);
-  font: 16px/1.6 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-}
-a { color: var(--accent); text-decoration: none; }
-a:hover { text-decoration: underline; }
-.layout {
-  display: grid;
-  grid-template-columns: 260px minmax(0, 1fr);
-  min-height: 100vh;
-}
-nav {
-  border-right: 1px solid var(--line);
-  padding: 28px 22px;
-  background: var(--panel);
-}
-.brand {
-  display: block;
-  color: var(--fg);
-  font-weight: 760;
-  font-size: 20px;
-  margin-bottom: 20px;
-}
-nav ul { list-style: none; margin: 0; padding: 0; }
-nav li { margin: 4px 0; }
-nav a {
-  display: block;
-  border-radius: 7px;
-  color: var(--muted);
-  padding: 8px 10px;
-}
-nav a.current {
-  background: var(--code);
-  color: var(--fg);
-  font-weight: 650;
-}
-main {
-  width: min(920px, 100%);
-  padding: 44px 32px 80px;
-}
-h1, h2, h3 { line-height: 1.2; margin: 1.8em 0 0.55em; }
-h1 { font-size: 38px; margin-top: 0; }
-h2 { font-size: 26px; border-top: 1px solid var(--line); padding-top: 1.1em; }
-h3 { font-size: 20px; }
-p, ul, ol, table, pre { margin: 0 0 1.15em; }
-ul, ol { padding-left: 1.45em; }
-code {
-  background: var(--code);
-  border-radius: 5px;
-  padding: 0.12em 0.32em;
-  font-size: 0.92em;
-}
-pre {
-  overflow-x: auto;
-  background: var(--code);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 15px 16px;
-}
-pre code {
-  background: transparent;
-  border-radius: 0;
-  padding: 0;
-}
-table {
-  border-collapse: collapse;
-  display: block;
-  overflow-x: auto;
-}
-th, td {
-  border: 1px solid var(--line);
-  padding: 8px 10px;
-  vertical-align: top;
-}
-th {
-  background: var(--code);
-  text-align: left;
-}
-blockquote {
-  border-left: 4px solid var(--line);
-  color: var(--muted);
-  margin: 0 0 1.15em;
-  padding-left: 14px;
-}
-@media (max-width: 760px) {
-  .layout { display: block; }
-  nav {
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
-    padding: 18px;
-  }
-  nav ul {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-  }
-  main { padding: 30px 20px 64px; }
-  h1 { font-size: 32px; }
-}
-`;
-
-css = `
-:root {
-  color-scheme: light;
-  --bg: #f9f9f9;
-  --surface: #ffffff;
-  --surface-muted: #fafafa;
-  --ink: #0a0a0a;
-  --ink-soft: #525252;
-  --line: rgba(0, 0, 0, 0.08);
-  --accent: #dc2626;
-  --accent-deep: #b91c1c;
-  --accent-subtle: rgba(220, 38, 38, 0.08);
-  --code-bg: #101012;
-  --code-fg: #f5f5f5;
-  --code-inline-bg: rgba(10, 10, 10, 0.05);
-  --shadow: 0 18px 46px rgba(10, 10, 10, 0.08);
-  --font-display: "Bricolage Grotesque", "Manrope", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  --font-body: "Manrope", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-:root[data-theme="dark"] {
-  color-scheme: dark;
-  --bg: #060608;
-  --surface: #0e0e10;
-  --surface-muted: #131315;
-  --ink: #fafafa;
-  --ink-soft: #a1a1a1;
-  --line: rgba(255, 255, 255, 0.08);
-  --accent: #dc2626;
-  --accent-deep: #ef4444;
-  --accent-subtle: rgba(220, 38, 38, 0.13);
-  --code-bg: #050507;
-  --code-fg: #f5f5f5;
-  --code-inline-bg: rgba(255, 255, 255, 0.07);
-  --shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
-}
-* { box-sizing: border-box; }
-html {
-  scroll-behavior: smooth;
-  scroll-padding-top: 24px;
-}
-body {
-  margin: 0;
-  min-height: 100vh;
-  background:
-    radial-gradient(circle at 52% -10%, color-mix(in srgb, var(--accent) 15%, transparent), transparent 32rem),
-    radial-gradient(circle at 92% 14%, color-mix(in srgb, var(--ink) 8%, transparent), transparent 30rem),
-    var(--bg);
-  color: var(--ink);
-  font: 15px/1.65 var(--font-body);
-  letter-spacing: 0;
-  overflow-x: hidden;
-  -webkit-font-smoothing: antialiased;
-}
-::selection { background: var(--accent); color: #fff; }
-a {
-  color: var(--accent);
-  text-decoration: none;
-  transition: color .12s, border-color .12s, background-color .12s;
-}
-a:hover {
-  color: var(--accent-deep);
-  text-decoration: underline;
-  text-underline-offset: 0.18em;
-}
-.layout {
-  display: grid;
-  grid-template-columns: 268px minmax(0, 1fr);
-  min-height: 100vh;
-}
-.sidebar {
-  position: sticky;
-  top: 0;
-  height: 100vh;
-  overflow: auto;
-  padding: 24px 22px;
-  border-right: 1px solid var(--line);
-  background: color-mix(in srgb, var(--surface) 88%, transparent);
-  backdrop-filter: blur(18px);
-  scrollbar-width: thin;
-  scrollbar-color: var(--line) transparent;
-}
-.sidebar-head {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 24px;
-}
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 11px;
-  min-width: 0;
-  flex: 1;
-  color: var(--ink);
-  text-decoration: none;
-}
-.brand:hover { text-decoration: none; color: var(--ink); }
-.brand-mark {
-  display: block;
-  width: 30px;
-  height: 30px;
-  flex: 0 0 30px;
-  border-radius: 7px;
-  object-fit: contain;
-}
-.brand strong {
-  display: block;
-  color: var(--ink);
-  font: 700 1.04rem/1.1 var(--font-display);
-  letter-spacing: 0;
-}
-.brand small {
-  display: block;
-  margin-top: 3px;
-  color: var(--ink-soft);
-  font-size: .74rem;
-  line-height: 1.2;
-}
-.theme-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  flex: 0 0 auto;
-  padding: 0;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface-muted);
-  color: var(--ink-soft);
-  cursor: pointer;
-}
-.theme-toggle:hover {
-  border-color: color-mix(in srgb, var(--ink) 24%, var(--line));
-  color: var(--ink);
-}
-.theme-toggle svg {
-  width: 16px;
-  height: 16px;
-  display: block;
-}
-.theme-icon-sun { display: none; }
-:root[data-theme="dark"] .theme-icon-moon { display: none; }
-:root[data-theme="dark"] .theme-icon-sun { display: block; }
-.search {
-  display: block;
-  margin-bottom: 22px;
-}
-.search span {
-  display: block;
-  margin-bottom: 7px;
-  color: var(--ink-soft);
-  font-size: .7rem;
-  font-weight: 700;
-  letter-spacing: .02em;
-  text-transform: uppercase;
-}
-.search input {
-  width: 100%;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface-muted);
-  color: var(--ink);
-  outline: none;
-  padding: 9px 12px;
-  font: inherit;
-  font-size: .9rem;
-}
-.search input:focus {
-  border-color: color-mix(in srgb, var(--accent) 58%, var(--line));
-  box-shadow: 0 0 0 3px var(--accent-subtle);
-}
-nav section { margin-bottom: 18px; }
-nav h2 {
-  margin: 0 0 6px;
-  color: var(--ink-soft);
-  font-size: .68rem;
-  font-weight: 700;
-  letter-spacing: .02em;
-  text-transform: uppercase;
-}
-.nav-link {
-  display: block;
-  margin: 1px 0;
-  border-radius: 6px;
-  color: var(--ink-soft);
-  padding: 5px 10px;
-  font-size: .9rem;
-  line-height: 1.42;
-}
-.nav-link:hover {
-  background: color-mix(in srgb, var(--ink) 5%, transparent);
-  color: var(--ink);
-  text-decoration: none;
-}
-.nav-link.current {
-  background: var(--accent-subtle);
-  color: var(--accent-deep);
-  font-weight: 700;
-}
-.nav-toggle {
-  display: none;
-  position: fixed;
-  top: calc(14px + env(safe-area-inset-top, 0px));
-  right: calc(14px + env(safe-area-inset-right, 0px));
-  z-index: 20;
-  width: 40px;
-  height: 40px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
-  color: var(--ink);
-  cursor: pointer;
-  padding: 10px 9px;
-  box-shadow: var(--shadow);
-  flex-direction: column;
-  justify-content: space-between;
-}
-.nav-toggle span {
-  display: block;
-  width: 100%;
-  height: 2px;
-  border-radius: 2px;
-  background: currentColor;
-  transition: transform .18s, opacity .18s;
-}
-.nav-toggle[aria-expanded="true"] span:nth-child(1) { transform: translateY(8px) rotate(45deg); }
-.nav-toggle[aria-expanded="true"] span:nth-child(2) { opacity: 0; }
-.nav-toggle[aria-expanded="true"] span:nth-child(3) { transform: translateY(-8px) rotate(-45deg); }
-main {
-  min-width: 0;
-  width: 100%;
-  max-width: 1180px;
-  margin: 0 auto;
-  padding: 32px clamp(20px, 4.5vw, 56px) 80px;
-}
-.hero {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 22px;
-  flex-wrap: wrap;
-  border-bottom: 1px solid var(--line);
-  padding: 8px 0 22px;
-  margin-bottom: 24px;
-}
-.eyebrow {
-  margin: 0 0 8px;
-  color: var(--ink-soft);
-  font-size: .7rem;
-  font-weight: 800;
-  letter-spacing: .03em;
-  text-transform: uppercase;
-}
-.hero h1 {
-  margin: 0;
-  color: var(--ink);
-  font: 800 2.3rem/1.06 var(--font-display);
-  letter-spacing: 0;
-}
-.hero-meta {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-.btn-ghost {
-  display: inline-flex;
-  align-items: center;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  background: var(--surface);
-  color: var(--ink-soft);
-  padding: 6px 11px;
-  font-size: .83rem;
-  font-weight: 700;
-}
-.btn-ghost:hover {
-  border-color: color-mix(in srgb, var(--ink) 24%, var(--line));
-  color: var(--ink);
-  text-decoration: none;
-}
-.doc-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 72ch) 200px;
-  gap: 48px;
-  align-items: start;
-}
-.doc {
-  min-width: 0;
-  max-width: 72ch;
-  overflow-wrap: break-word;
-}
-.doc h1 {
-  margin: 0 0 .45em;
-  color: var(--ink);
-  font: 800 2.5rem/1.08 var(--font-display);
-  letter-spacing: 0;
-}
-.doc > h1:first-child { display: none; }
-.doc h2 {
-  position: relative;
-  margin: 2em 0 .5em;
-  color: var(--ink);
-  font: 750 1.45rem/1.18 var(--font-display);
-  letter-spacing: 0;
-}
-.doc h3 {
-  position: relative;
-  margin: 1.65em 0 .35em;
-  color: var(--ink);
-  font: 750 1.08rem/1.25 var(--font-display);
-}
-.doc h1:first-child,
-.doc h2:first-child,
-.doc h3:first-child { margin-top: 0; }
-.doc p,
-.doc ul,
-.doc ol,
-.doc table,
-.doc pre { margin: 0 0 1.12em; }
-.doc ul,
-.doc ol { padding-left: 1.35rem; }
-.doc li { margin: .25em 0; }
-.doc strong { color: var(--ink); font-weight: 800; }
-code { font-family: var(--font-mono); }
-.doc code {
-  background: var(--code-inline-bg);
-  border: 1px solid var(--line);
-  border-radius: 5px;
-  color: var(--ink);
-  padding: .08em .35em;
-  font-size: .86em;
-}
-.doc pre {
-  position: relative;
-  overflow-x: auto;
-  background: var(--code-bg);
-  border: 1px solid color-mix(in srgb, var(--line) 75%, #000);
-  border-radius: 8px;
-  color: var(--code-fg);
-  padding: 14px 18px;
-  font-size: .86em;
-  line-height: 1.62;
-  box-shadow: 0 18px 44px rgba(0, 0, 0, .14);
-}
-.doc pre code {
-  display: block;
-  background: transparent;
-  border: 0;
-  border-radius: 0;
-  color: inherit;
-  font-size: 1em;
-  padding: 0;
-  white-space: pre;
-}
-.copy {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  border: 1px solid rgba(255, 255, 255, .16);
-  border-radius: 6px;
-  background: rgba(255, 255, 255, .08);
-  color: var(--code-fg);
-  cursor: pointer;
-  opacity: 0;
-  padding: 4px 9px;
-  font: 700 .7rem/1 var(--font-body);
-  transition: opacity .12s, background-color .12s;
-}
-.doc pre:hover .copy,
-.copy:focus { opacity: 1; }
-.copy:hover { background: rgba(255, 255, 255, .14); }
-.copy.copied {
-  opacity: 1;
-  background: var(--accent);
-  border-color: var(--accent);
-}
-table {
-  width: 100%;
-  border-collapse: collapse;
-  display: block;
-  overflow-x: auto;
-  font-size: .92em;
-}
-th, td {
-  border-bottom: 1px solid var(--line);
-  padding: 9px 10px;
-  vertical-align: top;
-  text-align: left;
-}
-th {
-  background: color-mix(in srgb, var(--ink) 5%, transparent);
-  color: var(--ink);
-  font-weight: 800;
-}
-blockquote {
-  margin: 1.35em 0;
-  border-left: 3px solid var(--accent);
-  border-radius: 0 8px 8px 0;
-  background: var(--accent-subtle);
-  color: var(--ink);
-  padding: 10px 16px;
-}
-blockquote p:last-child { margin-bottom: 0; }
-.toc {
-  position: sticky;
-  top: 24px;
-  max-height: calc(100vh - 48px);
-  overflow: auto;
-  border-left: 1px solid var(--line);
-  padding-left: 14px;
-  font-size: .84rem;
-}
-.toc h2 {
-  margin: 0 0 10px;
-  color: var(--ink-soft);
-  font-size: .66rem;
-  font-weight: 800;
-  letter-spacing: .03em;
-  text-transform: uppercase;
-}
-.toc a {
-  display: block;
-  border-left: 2px solid transparent;
-  margin-left: -12px;
-  padding: 4px 0 4px 10px;
-  color: var(--ink-soft);
-  line-height: 1.35;
-}
-.toc a:hover {
-  color: var(--ink);
-  text-decoration: none;
-}
-.toc a.active {
-  border-left-color: var(--accent);
-  color: var(--accent-deep);
-  font-weight: 700;
-}
-.toc-l3 {
-  padding-left: 22px !important;
-  font-size: .94em;
-}
-.page-nav {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-  margin-top: 48px;
-  border-top: 1px solid var(--line);
-  padding-top: 20px;
-}
-.page-nav a {
-  display: block;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
-  color: var(--ink-soft);
-  padding: 13px 16px;
-}
-.page-nav a:hover {
-  border-color: color-mix(in srgb, var(--accent) 48%, var(--line));
-  color: var(--ink);
-  text-decoration: none;
-}
-.page-nav small {
-  display: block;
-  margin-bottom: 5px;
-  color: var(--ink-soft);
-  font-size: .7rem;
-  font-weight: 800;
-  letter-spacing: .03em;
-  text-transform: uppercase;
-}
-.page-nav span {
-  display: block;
-  color: var(--ink);
-  font-weight: 800;
-  line-height: 1.3;
-}
-.page-nav-next { text-align: right; grid-column: 2; }
-.page-nav-prev:only-child { grid-column: 1; }
-@media (max-width: 1179px) {
-  .doc-grid { grid-template-columns: minmax(0, 72ch); }
-  .toc { display: none; }
-}
-@media (max-width: 900px) {
-  .layout { display: block; }
-  .sidebar {
-    position: fixed;
-    inset: 0 30% 0 0;
-    z-index: 15;
-    max-width: 320px;
-    transform: translateX(-100%);
-    background: var(--surface);
-    box-shadow: var(--shadow);
-    transition: transform .22s ease;
-    pointer-events: none;
-  }
-  .sidebar.open {
-    transform: translateX(0);
-    pointer-events: auto;
-  }
-  .nav-toggle { display: flex; }
-  main { padding: 64px 18px 56px; }
-  .hero h1 { font-size: 1.85rem; }
-  .doc h1 { font-size: 2.1rem; }
-}
-@media (max-width: 520px) {
-  main { padding: 60px 14px 48px; }
-  .doc pre {
-    margin-left: -14px;
-    margin-right: -14px;
-    border-radius: 0;
-    border-left: 0;
-    border-right: 0;
-  }
-  .page-nav { grid-template-columns: 1fr; }
-  .page-nav-next { grid-column: 1; text-align: left; }
-}
-`;
 
 await rm(outDir, { recursive: true, force: true });
 await mkdir(outDir, { recursive: true });
-await mkdir(outAssetsDir, { recursive: true });
-await writeFile(path.join(outDir, 'style.css'), css.trimStart());
+await cp(assetsDir, outAssetsDir, { recursive: true });
 await writeFile(path.join(outDir, '.nojekyll'), '');
-
-for (const asset of assets) {
-  await copyFile(path.join(assetsDir, asset), path.join(outAssetsDir, asset));
-}
 
 for (const [file, title] of pages) {
   const markdown = await readFile(path.join(docsDir, file), 'utf8');
@@ -698,7 +45,8 @@ function pageShell(currentFile, title, body) {
           const label = pageMap.get(file);
           const href = file.replace(/\.md$/, '.html');
           const current = file === currentFile ? ' current' : '';
-          return `<a class="nav-link${current}" href="${href}">${escapeHtml(label)}</a>`;
+          const currentPage = file === currentFile ? ' aria-current="page"' : '';
+          return `<a class="nav-link${current}" href="${href}"${currentPage}>${escapeHtml(label)}</a>`;
         })
         .join('');
       return `<section><h2>${escapeHtml(section)}</h2>${links}</section>`;
@@ -707,55 +55,85 @@ function pageShell(currentFile, title, body) {
   const currentIndex = pages.findIndex(([file]) => file === currentFile);
   const pageNav = renderPageNav(pages[currentIndex - 1], pages[currentIndex + 1]);
   const toc = renderToc(body);
-  const homeClass = currentFile === 'index.md' ? ' class="home"' : '';
-  const heroTitle = title;
+  const isHome = currentFile === 'index.md';
+  const sectionName =
+    navSections.find(([, files]) => files.includes(currentFile))?.[0] ?? 'Documentation';
+  const pageIntro = isHome ? renderHomeIntro() : renderPageHeading(title, sectionName);
+  const bodyClass = isHome ? 'oc-app-surface home' : 'oc-app-surface docs-page';
+
   return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${escapeHtml(title)} - ClawScan</title>
+  <title>${escapeHtml(title)} · ClawScan Docs</title>
   <meta name="description" content="ClawScan is an open, benchmarkable security scanning harness for agent skills.">
+  <meta name="theme-color" content="#f6f5f3" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#101012" media="(prefers-color-scheme: dark)">
   <meta property="og:image" content="assets/clawscan-banner.png">
   <link rel="icon" href="assets/clawscan-logo.png" type="image/png">
   <link rel="apple-touch-icon" href="assets/clawscan-logo.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@600;700;800&family=IBM+Plex+Mono:wght@400;500;600&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <script>(function(){var s;try{s=localStorage.getItem('theme')}catch(e){}var d=window.matchMedia&&matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.dataset.theme=s||(d?'dark':'light')})();</script>
-  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Instrument+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script>(function(){var s;try{s=localStorage.getItem('clawscan-theme')}catch(e){}var d=window.matchMedia&&matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.dataset.theme=s||(d?'dark':'light')})();</script>
+  <link rel="stylesheet" href="assets/carapace/tokens.css">
+  <link rel="stylesheet" href="assets/carapace/themes.css">
+  <link rel="stylesheet" href="assets/carapace/typography.css">
+  <link rel="stylesheet" href="assets/carapace/components.css">
+  <link rel="stylesheet" href="assets/site.css">
+  <script src="assets/site.js" defer></script>
 </head>
-<body${homeClass}>
-  <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
-    <span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>
-  </button>
-  <div class="layout">
-    <aside class="sidebar">
-      <div class="sidebar-head">
-        <a class="brand" href="index.html" aria-label="ClawScan docs home">
-          <img class="brand-mark" src="assets/clawscan-logo.png" alt="" width="30" height="30" aria-hidden="true">
-          <span><strong>ClawScan</strong><small>Composable security scanning harness for agent skills</small></span>
-        </a>
-        <button class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false" data-theme-toggle>
-          <svg class="theme-icon-moon" viewBox="0 0 20 20" aria-hidden="true"><path d="M14.6 12.1A6.5 6.5 0 0 1 7.4 2.7a6.5 6.5 0 1 0 7.2 9.4z" fill="currentColor"/></svg>
-          <svg class="theme-icon-sun" viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="3.4" fill="currentColor"/><g stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><line x1="10" y1="2" x2="10" y2="4"/><line x1="10" y1="16" x2="10" y2="18"/><line x1="2" y1="10" x2="4" y2="10"/><line x1="16" y1="10" x2="18" y2="10"/><line x1="4.2" y1="4.2" x2="5.6" y2="5.6"/><line x1="14.4" y1="14.4" x2="15.8" y2="15.8"/><line x1="4.2" y1="15.8" x2="5.6" y2="14.4"/><line x1="14.4" y1="5.6" x2="15.8" y2="4.2"/></g></svg>
-        </button>
-      </div>
-      <label class="search"><span>Search</span><input id="doc-search" type="search" placeholder="scanners, judge, benchmarks"></label>
-      <nav aria-label="Documentation">
+<body class="${bodyClass}">
+  <a class="skip-link oc-action oc-action-primary" href="#main-content">Skip to content</a>
+  <header class="topbar">
+    <a class="brand" href="index.html" aria-label="ClawScan documentation home">
+      <img class="brand-mark" src="assets/clawscan-logo.png" alt="" width="29" height="29" aria-hidden="true">
+      <span class="brand-product">ClawScan</span>
+      <span class="brand-divider" aria-hidden="true">/</span>
+      <span class="brand-section">docs</span>
+    </a>
+    <div class="topbar-center">
+      <button class="install-command" type="button" data-copy-install aria-label="Copy npm install command">
+        <span class="install-prompt" aria-hidden="true">$</span>
+        <code>npm install -g @openclaw/clawscan</code>
+        <span class="install-copy" aria-hidden="true">Copy</span>
+      </button>
+    </div>
+    <div class="topbar-actions">
+      <a class="source-link oc-action oc-action-ghost" href="https://github.com/openclaw/clawscan" rel="noopener">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.9c-2.78.6-3.37-1.18-3.37-1.18-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.9 1.53 2.35 1.09 2.92.83.09-.65.35-1.09.64-1.34-2.22-.25-4.56-1.11-4.56-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.6 9.6 0 0 1 12 6.79a9.6 9.6 0 0 1 2.5.34c1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.86V21c0 .27.18.58.69.48A10 10 0 0 0 12 2Z"/></svg>
+        <span>Source</span>
+      </a>
+      <button class="icon-button" type="button" data-theme-toggle aria-label="Switch color theme" aria-pressed="false">
+        <svg class="theme-icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M20.1 15.5A8.5 8.5 0 0 1 8.5 3.9 8.5 8.5 0 1 0 20.1 15.5Z"/></svg>
+        <svg class="theme-icon-sun" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Zm0-6 1 3h-2l1-3Zm0 20-1-3h2l-1 3ZM2 12l3-1v2l-3-1Zm20 0-3 1v-2l3 1ZM4.9 4.9l2.8 1.4-1.4 1.4-1.4-2.8Zm14.2 14.2-2.8-1.4 1.4-1.4 1.4 2.8Zm0-14.2-1.4 2.8-1.4-1.4 2.8-1.4ZM4.9 19.1l1.4-2.8 1.4 1.4-2.8 1.4Z"/></svg>
+      </button>
+      <button class="nav-toggle" type="button" aria-label="Toggle documentation navigation" aria-expanded="false" aria-controls="docs-sidebar">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M4 6h16v2H4V6Zm0 5h16v2H4v-2Zm0 5h16v2H4v-2Z"/></svg>
+      </button>
+    </div>
+  </header>
+  <aside class="sidebar" id="docs-sidebar">
+    <div class="sidebar-inner">
+      <p class="sidebar-kicker">Documentation</p>
+      <label class="search" for="doc-search">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="m20.7 19.3-4.1-4.1a7.5 7.5 0 1 0-1.4 1.4l4.1 4.1 1.4-1.4ZM5 11a6 6 0 1 1 12 0 6 6 0 0 1-12 0Z"/></svg>
+        <input id="doc-search" type="search" placeholder="Filter docs…" autocomplete="off">
+      </label>
+      <nav class="docs-nav" aria-label="Documentation">
 ${nav}
       </nav>
-    </aside>
-    <main>
-      <header class="hero">
-        <div>
-          <h1>${escapeHtml(heroTitle)}</h1>
-        </div>
-        <div class="hero-meta">
-          <a class="btn-ghost" href="https://github.com/openclaw/clawscan" rel="noopener">GitHub</a>
-          <a class="btn-ghost" href="index.html#quick-start">Quickstart</a>
-        </div>
-      </header>
+      <div class="sidebar-footer">
+        <span>Carapace v0.6.1</span>
+        <a href="https://carapace.design/" rel="noopener">Design system ↗</a>
+      </div>
+    </div>
+  </aside>
+  <button class="sidebar-overlay" type="button" aria-label="Close documentation navigation" hidden></button>
+  <main class="site-main" id="main-content">
+    <div class="page-frame">
+${pageIntro}
       <div class="doc-grid">
         <article class="doc">
 ${body}
@@ -763,126 +141,78 @@ ${pageNav}
         </article>
 ${toc}
       </div>
-    </main>
-  </div>
-  <script>
-const themeRoot = document.documentElement;
-function applyTheme(mode) {
-  themeRoot.dataset.theme = mode;
-  document.querySelectorAll('[data-theme-toggle]').forEach((button) => {
-    button.setAttribute('aria-pressed', mode === 'dark' ? 'true' : 'false');
-  });
-}
-function storedTheme() {
-  try { return localStorage.getItem('theme'); } catch { return null; }
-}
-function persistTheme(mode) {
-  try { localStorage.setItem('theme', mode); } catch {}
-}
-applyTheme(themeRoot.dataset.theme === 'dark' ? 'dark' : 'light');
-document.querySelectorAll('[data-theme-toggle]').forEach((button) => {
-  button.addEventListener('click', () => {
-    const next = themeRoot.dataset.theme === 'dark' ? 'light' : 'dark';
-    applyTheme(next);
-    persistTheme(next);
-  });
-});
-const systemDark = window.matchMedia && matchMedia('(prefers-color-scheme: dark)');
-function onSystemChange(event) {
-  if (storedTheme()) return;
-  applyTheme(event.matches ? 'dark' : 'light');
-}
-if (systemDark) {
-  if (systemDark.addEventListener) systemDark.addEventListener('change', onSystemChange);
-  else if (systemDark.addListener) systemDark.addListener(onSystemChange);
-}
-const sidebar = document.querySelector('.sidebar');
-const toggle = document.querySelector('.nav-toggle');
-const mobileNav = window.matchMedia('(max-width: 900px)');
-function setSidebarOpen(open) {
-  if (!sidebar || !toggle) return;
-  sidebar.classList.toggle('open', open);
-  toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
-  if (mobileNav.matches) {
-    if (open) sidebar.removeAttribute('aria-hidden');
-    else sidebar.setAttribute('aria-hidden', 'true');
-  } else {
-    sidebar.removeAttribute('aria-hidden');
-  }
-}
-setSidebarOpen(false);
-toggle?.addEventListener('click', () => setSidebarOpen(!sidebar?.classList.contains('open')));
-document.addEventListener('click', (event) => {
-  if (!sidebar?.classList.contains('open')) return;
-  if (sidebar.contains(event.target) || toggle?.contains(event.target)) return;
-  setSidebarOpen(false);
-});
-document.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape') setSidebarOpen(false);
-});
-if (mobileNav.addEventListener) mobileNav.addEventListener('change', () => setSidebarOpen(false));
-else mobileNav.addListener?.(() => setSidebarOpen(false));
-const input = document.getElementById('doc-search');
-input?.addEventListener('input', () => {
-  const query = input.value.trim().toLowerCase();
-  document.querySelectorAll('nav section').forEach((section) => {
-    let any = false;
-    section.querySelectorAll('.nav-link').forEach((link) => {
-      const match = !query || link.textContent.toLowerCase().includes(query);
-      link.style.display = match ? 'block' : 'none';
-      if (match) any = true;
-    });
-    section.style.display = any ? 'block' : 'none';
-  });
-});
-document.querySelectorAll('.doc pre').forEach((pre) => {
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'copy';
-  button.textContent = 'Copy';
-  button.addEventListener('click', async () => {
-    try {
-      await navigator.clipboard.writeText(pre.querySelector('code')?.textContent ?? '');
-      button.textContent = 'Copied';
-      button.classList.add('copied');
-      setTimeout(() => {
-        button.textContent = 'Copy';
-        button.classList.remove('copied');
-      }, 1400);
-    } catch {
-      button.textContent = 'Failed';
-      setTimeout(() => {
-        button.textContent = 'Copy';
-      }, 1400);
-    }
-  });
-  pre.appendChild(button);
-});
-const tocLinks = document.querySelectorAll('.toc a');
-if (tocLinks.length) {
-  const byElement = new Map();
-  tocLinks.forEach((link) => {
-    const id = link.getAttribute('href').slice(1);
-    const element = document.getElementById(id);
-    if (element) byElement.set(element, link);
-  });
-  const setActive = (link) => {
-    tocLinks.forEach((item) => item.classList.remove('active'));
-    link.classList.add('active');
-  };
-  const observer = new IntersectionObserver((entries) => {
-    const visible = entries.filter((entry) => entry.isIntersecting).sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-    if (visible.length) {
-      const link = byElement.get(visible[0].target);
-      if (link) setActive(link);
-    }
-  }, { rootMargin: '-15% 0px -65% 0px', threshold: 0 });
-  byElement.forEach((_link, element) => observer.observe(element));
-}
-  </script>
+    </div>
+  </main>
 </body>
 </html>
 `;
+}
+
+function renderPageHeading(title, section) {
+  return `<header class="page-heading">
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <a href="index.html">Docs</a>
+    <span aria-hidden="true">/</span>
+    <span>${escapeHtml(section)}</span>
+  </nav>
+  <h1>${escapeHtml(title)}</h1>
+</header>`;
+}
+
+function renderHomeIntro() {
+  return `<section class="home-hero" aria-labelledby="home-title">
+  <div class="home-hero-copy">
+    <p class="oc-eyebrow">OpenClaw security / ClawScan</p>
+    <h1 id="home-title">Scan the skill.<br><span>Keep the evidence.</span></h1>
+    <p class="home-lede">Run multiple agent-skill scanners, preserve their raw findings, and add an optional judge—without hiding what each tool actually reported.</p>
+    <div class="home-actions">
+      <a class="oc-action oc-action-primary" href="#quick-start">Install ClawScan</a>
+      <a class="oc-action oc-action-secondary" href="scanners.html">Explore scanners</a>
+    </div>
+    <div class="home-proof" aria-label="ClawScan capabilities">
+      <span><i aria-hidden="true"></i>Composable scanners</span>
+      <span><i aria-hidden="true"></i>Raw JSON evidence</span>
+      <span><i aria-hidden="true"></i>Benchmarkable profiles</span>
+    </div>
+  </div>
+  <div class="scan-console" aria-label="Example ClawScan run">
+    <div class="scan-console-head">
+      <span>Example run</span>
+      <span class="window-dots" aria-hidden="true"><i></i><i></i><i></i></span>
+    </div>
+    <div class="scan-console-command"><b>$</b> clawscan ./my-skill<br>&nbsp;&nbsp;--scanner skillspector --scanner cisco</div>
+    <div class="scan-console-row"><span>skillspector</span><strong>completed</strong></div>
+    <div class="scan-console-row"><span>cisco</span><strong>completed</strong></div>
+    <div class="scan-console-result">
+      <div><small>targets</small><strong>1</strong></div>
+      <div><small>scanners</small><strong>2</strong></div>
+      <div><small>artifact</small><strong>JSON</strong></div>
+    </div>
+  </div>
+</section>
+<section class="pipeline" aria-label="ClawScan pipeline">
+  <div class="pipeline-step"><small>01 / Input</small><strong>Agent skill</strong></div>
+  <div class="pipeline-step"><small>02 / Inspect</small><strong>Scanner suite</strong></div>
+  <div class="pipeline-step"><small>03 / Preserve</small><strong>Raw evidence</strong></div>
+  <div class="pipeline-step"><small>04 / Decide</small><strong>Optional judge</strong></div>
+</section>
+<nav class="home-cards" aria-label="Start with ClawScan">
+  <a class="home-card oc-card oc-card-interactive" href="scanners.html">
+    <small>Scanner catalog</small>
+    <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="m8 5 7 7-7 7 1.4 1.4 8.4-8.4-8.4-8.4L8 5Z"/></svg>
+    <strong>Choose what inspects your skill.</strong>
+  </a>
+  <a class="home-card oc-card oc-card-interactive" href="profiles.html">
+    <small>Profiles</small>
+    <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="m8 5 7 7-7 7 1.4 1.4 8.4-8.4-8.4-8.4L8 5Z"/></svg>
+    <strong>Save a repeatable scan setup.</strong>
+  </a>
+  <a class="home-card oc-card oc-card-interactive" href="benchmarks.html">
+    <small>Benchmarks</small>
+    <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="m8 5 7 7-7 7 1.4 1.4 8.4-8.4-8.4-8.4L8 5Z"/></svg>
+    <strong>Measure the setup against known data.</strong>
+  </a>
+</nav>`;
 }
 
 function renderPageNav(previousPage, nextPage) {
@@ -890,10 +220,10 @@ function renderPageNav(previousPage, nextPage) {
     return '';
   }
   const previous = previousPage
-    ? `<a class="page-nav-prev" href="${previousPage[0].replace(/\.md$/, '.html')}"><small>Previous</small><span>${escapeHtml(previousPage[1])}</span></a>`
+    ? `<a class="page-nav-prev oc-card oc-card-interactive" href="${previousPage[0].replace(/\.md$/, '.html')}"><small>Previous</small><span>${escapeHtml(previousPage[1])}</span></a>`
     : '';
   const next = nextPage
-    ? `<a class="page-nav-next" href="${nextPage[0].replace(/\.md$/, '.html')}"><small>Next</small><span>${escapeHtml(nextPage[1])}</span></a>`
+    ? `<a class="page-nav-next oc-card oc-card-interactive" href="${nextPage[0].replace(/\.md$/, '.html')}"><small>Next</small><span>${escapeHtml(nextPage[1])}</span></a>`
     : '';
   return `<nav class="page-nav" aria-label="Page navigation">${previous}${next}</nav>`;
 }
@@ -1096,7 +426,7 @@ function renderTable(rows) {
   const rowsHtml = body
     .map((row) => `<tr>${row.map((cell) => `<td>${renderInline(cell)}</td>`).join('')}</tr>`)
     .join('');
-  return `<table>${head}<tbody>${rowsHtml}</tbody></table>`;
+  return `<div class="table-scroll" tabindex="0" role="region" aria-label="Scrollable data table"><table>${head}<tbody>${rowsHtml}</tbody></table></div>`;
 }
 
 function parseTableRow(line) {


### PR DESCRIPTION
## What Problem This Solves

The ClawScan documentation site used a one-off visual layer that did not match the OpenClaw Carapace design system.

## Why This Change Was Made

Rebuild the six-page static docs site around vendored Carapace v0.6.1 tokens, themes, typography, and components while keeping the existing Markdown content and GitHub Pages pipeline.

## User Impact

- Gives ClawScan a responsive Carapace-based docs shell and home page.
- Preserves navigation, theme switching, doc filtering, copy controls, page navigation, and table-of-contents behavior.
- Keeps generated `dist/docs-site` output out of the repository; Pages rebuilds it from source.

## Evidence

- `make docs-site` — built 6 docs pages.
- `git diff --check` — passed.
- `node --check scripts/build-docs-site.mjs` — passed.
- `node --check docs/assets/site.js` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean after fixing the navigation filter hidden-state bug it identified.
- Local preview returned HTTP 200 at `http://127.0.0.1:4176/`.
