### PR TITLE
docs: remove design system footer

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -370,22 +370,6 @@ html[data-theme="dark"] .theme-icon-sun {
   content: "";
 }
 
-.sidebar-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--oc-space-2);
-  margin-top: auto;
-  padding: var(--oc-space-5) var(--oc-space-2) 0;
-  color: var(--oc-text-muted);
-  font-family: var(--oc-font-mono);
-  font-size: 0.66rem;
-}
-
-.sidebar-footer a {
-  color: inherit;
-}
-
 .sidebar-overlay {
   display: none;
 }

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -124,10 +124,6 @@ function pageShell(currentFile, title, body) {
       <nav class="docs-nav" aria-label="Documentation">
 ${nav}
       </nav>
-      <div class="sidebar-footer">
-        <span>Carapace v0.6.1</span>
-        <a href="https://carapace.design/" rel="noopener">Design system ↗</a>
-      </div>
     </div>
   </aside>
   <button class="sidebar-overlay" type="button" aria-label="Close documentation navigation" hidden></button>


### PR DESCRIPTION
## Summary

- What changed: removed the Carapace version and design-system link block from the documentation sidebar, along with its unused CSS.
- Why: the docs navigation should end with ClawScan content rather than an implementation-detail footer.

## Scope

- [ ] CLI behavior
- [ ] Scanner adapter
- [ ] Judge/profile/benchmark behavior
- [ ] ClawHub profile proposal at `proposals/<GHSA-ID>/clawscan.yml`
- [x] Docs only
- [ ] Release/CI/repo automation

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

No scanner execution, judge commands, prompt/schema handling, secret redaction, benchmark submissions, or generated release artifacts change.

## Verification

- [ ] `go test -count=1 ./...`
- [ ] `go vet ./...`
- [ ] `go run ./cmd/clawscan --help`
- [x] Focused scanner/benchmark/manual proof: generated DOM checked in the Codex app browser at mobile, tablet, laptop, and desktop viewports; footer content and empty spacing are absent.
- [ ] For ClawHub profile proposals: I opened the sensitive report through GitHub private vulnerability reporting, and this PR contains only `proposals/<GHSA-ID>/clawscan.yml`
- [ ] For ClawHub profile proposals: I did not edit official bundled profile files under `internal/profiles/`
- [x] Docs site proof (`make docs-site`) or `N/A`: `make docs-site`; `node --check scripts/build-docs-site.mjs`; `node --check docs/assets/site.js`; `git diff --check`

## Notes

- Autoreview: clean, no accepted/actionable findings.
- Go tests and vet were not run because this two-file docs-shell change does not touch Go behavior.
