### PR TITLE
fix(runner): cap HTTP --ids response bodies

### DIFF
--- a/internal/runner/benchmark.go
+++ b/internal/runner/benchmark.go
@@ -39,6 +39,11 @@ const (
 	huggingFaceRowsEndpoint       = "https://datasets-server.huggingface.co/rows"
 	huggingFaceRowsPageSize       = 100
 	huggingFaceRowsMaxAttempts    = 6
+
+	// maxBenchmarkIDSourceBytes caps HTTP --ids bodies. Unbounded ReadAll
+	// would let a remote source allocate arbitrarily. Matches sibling
+	// 256 KiB caps (installpolicy maxRequestBytes, plugin manifest).
+	maxBenchmarkIDSourceBytes = 256 * 1024
 )
 
 var huggingFaceRowsRetryDelay = 2 * time.Second
@@ -338,7 +343,14 @@ func readBenchmarkIDSource(source string) ([]byte, error) {
 		if resp.StatusCode < 200 || resp.StatusCode > 299 {
 			return nil, fmt.Errorf("read --ids source %s: HTTP %d", source, resp.StatusCode)
 		}
-		return io.ReadAll(resp.Body)
+		data, err := io.ReadAll(io.LimitReader(resp.Body, maxBenchmarkIDSourceBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("read --ids source %s: %w", source, err)
+		}
+		if len(data) > maxBenchmarkIDSourceBytes {
+			return nil, fmt.Errorf("read --ids source %s: body exceeds %d bytes", source, maxBenchmarkIDSourceBytes)
+		}
+		return data, nil
 	}
 	data, err := os.ReadFile(source)
 	if err != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -754,6 +754,26 @@ func TestLoadBenchmarkIDSelectionAcceptsTextAndHTTPJSONL(t *testing.T) {
 	}
 }
 
+func TestLoadBenchmarkIDSelectionRejectsOversizedHTTPBody(t *testing.T) {
+	var body bytes.Buffer
+	for i := 0; body.Len() <= maxBenchmarkIDSourceBytes; i++ {
+		fmt.Fprintf(&body, "case_%08d\n", i)
+	}
+	if body.Len() <= maxBenchmarkIDSourceBytes {
+		t.Fatalf("test body is %d bytes, want more than %d", body.Len(), maxBenchmarkIDSourceBytes)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body.Bytes())
+	}))
+	defer server.Close()
+
+	_, err := LoadBenchmarkIDSelection(server.URL + "/ids.txt")
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("err = %v, want exceeds %d bytes", err, maxBenchmarkIDSourceBytes)
+	}
+}
+
 func TestLoadBenchmarkIDSelectionRejectsBadSources(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## What Problem This Solves

`clawscan benchmark ... --ids <url>` fetched the ID list with `io.ReadAll` and no size cap. A large or slow-trickle HTTP body can OOM the CLI. Sibling reads already cap at 256 KiB (`installpolicy.maxRequestBytes`, plugin manifests).

## Evidence

```console
Red (unfixed): TestLoadBenchmarkIDSelectionRejectsOversizedHTTPBody
    err = <nil>, want exceeds 262144 bytes
Green: go test -count=1 -run TestLoadBenchmarkIDSelection ./internal/runner/
ok
```

## Real behavior proof
Behavior addressed: HTTP `--ids` bodies larger than 256 KiB are rejected instead of being fully buffered.
Real environment tested: macOS, Go from the worktree, clawscan `/tmp/oc-impl-clawscan-ids` head `fb0eddd`.
Exact steps or command run after this patch: `go test -count=1 -run TestLoadBenchmarkIDSelection ./internal/runner/`
Evidence after fix: red/green recorded above.
Observed result after fix: httptest body of cap+1 is rejected with `body exceeds 262144 bytes`.
What was not tested: HuggingFace test-case JSONL fetches (different path; a 256 KiB cap would break real SkillTrustBench pages).
