### PR TITLE
fix(runner): honor cancel during HuggingFace retry backoff

### DIFF
--- a/cmd/clawscan/main.go
+++ b/cmd/clawscan/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -76,9 +74,7 @@ func run(args []string, environ []string) error {
 		opts.OutputPath = defaultOutputPath
 	}
 	if opts.Benchmark != nil {
-		runCtx, stop := newBenchmarkRunContext(environ)
-		defer stop()
-		artifact, err := runner.RunBenchmark(opts, runCtx)
+		artifact, err := runner.RunBenchmark(opts, benchmarkRunContext(environ))
 		if err != nil {
 			return err
 		}
@@ -287,9 +283,10 @@ func hasInstallPolicyConfigOverride(args []string) bool {
 	return false
 }
 
-func newBenchmarkRunContext(environ []string) (runner.RunContext, context.CancelFunc) {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-	return runner.RunContext{Context: ctx, Env: runner.EnvMap(environ)}, stop
+func benchmarkRunContext(environ []string) runner.RunContext {
+	// Keep SIGINT at the process default until every benchmark phase observes Context.
+	// A signal-derived context would otherwise swallow interrupts during scanner runs and downloads.
+	return runner.RunContext{Env: runner.EnvMap(environ)}
 }
 
 func runBenchmarkCommand(args []string, environ []string) error {
@@ -318,9 +315,7 @@ func runBenchmarkCommand(args []string, environ []string) error {
 	if !opts.JSON && opts.OutputPath == "" {
 		opts.OutputPath = defaultOutputPath
 	}
-	runCtx, stop := newBenchmarkRunContext(environ)
-	defer stop()
-	artifact, err := runner.RunBenchmark(opts, runCtx)
+	artifact, err := runner.RunBenchmark(opts, benchmarkRunContext(environ))
 	if err != nil {
 		return err
 	}

--- a/cmd/clawscan/main.go
+++ b/cmd/clawscan/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -74,7 +76,9 @@ func run(args []string, environ []string) error {
 		opts.OutputPath = defaultOutputPath
 	}
 	if opts.Benchmark != nil {
-		artifact, err := runner.RunBenchmark(opts, runner.RunContext{Env: runner.EnvMap(environ)})
+		runCtx, stop := newBenchmarkRunContext(environ)
+		defer stop()
+		artifact, err := runner.RunBenchmark(opts, runCtx)
 		if err != nil {
 			return err
 		}
@@ -283,6 +287,11 @@ func hasInstallPolicyConfigOverride(args []string) bool {
 	return false
 }
 
+func newBenchmarkRunContext(environ []string) (runner.RunContext, context.CancelFunc) {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	return runner.RunContext{Context: ctx, Env: runner.EnvMap(environ)}, stop
+}
+
 func runBenchmarkCommand(args []string, environ []string) error {
 	switch {
 	case len(args) == 1 && args[0] == "list":
@@ -309,7 +318,9 @@ func runBenchmarkCommand(args []string, environ []string) error {
 	if !opts.JSON && opts.OutputPath == "" {
 		opts.OutputPath = defaultOutputPath
 	}
-	artifact, err := runner.RunBenchmark(opts, runner.RunContext{Env: runner.EnvMap(environ)})
+	runCtx, stop := newBenchmarkRunContext(environ)
+	defer stop()
+	artifact, err := runner.RunBenchmark(opts, runCtx)
 	if err != nil {
 		return err
 	}

--- a/cmd/clawscan/main_test.go
+++ b/cmd/clawscan/main_test.go
@@ -89,6 +89,16 @@ func TestRunCommandPrintsHelp(t *testing.T) {
 	}
 }
 
+func TestBenchmarkRunContextLeavesInterruptHandlingToProcess(t *testing.T) {
+	runCtx := benchmarkRunContext([]string{"CLAWSCAN_PROOF=present"})
+	if runCtx.Context != nil {
+		t.Fatal("benchmark CLI must not capture interrupts until every benchmark phase observes context")
+	}
+	if runCtx.Env["CLAWSCAN_PROOF"] != "present" {
+		t.Fatalf("environment = %v", runCtx.Env)
+	}
+}
+
 func TestRunOpenClawInstallPolicyScansSkillAndPluginTargets(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/runner/benchmark.go
+++ b/internal/runner/benchmark.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -180,6 +181,7 @@ type HuggingFaceBenchmarkClient struct {
 	SkillTrustBenchArchiveURL  string
 	SkillTrustBenchArchivePath string
 	SkillTrustBenchRowsURL     string
+	Context                    context.Context
 }
 
 type huggingFaceRowsResponse struct {
@@ -249,7 +251,7 @@ func RunBenchmark(opts Options, ctx RunContext) (BenchmarkArtifact, error) {
 	startedAt := now().UTC().Format(time.RFC3339Nano)
 	client := ctx.BenchmarkClient
 	if client == nil {
-		client = HuggingFaceBenchmarkClient{}
+		client = HuggingFaceBenchmarkClient{Context: ctx.Context}
 	}
 	artifact := BenchmarkArtifact{
 		SchemaVersion: "clawscan-benchmark-v1",
@@ -756,7 +758,7 @@ func (client HuggingFaceBenchmarkClient) FetchOpenClawRows(dataset string, split
 				length = remaining
 			}
 		}
-		page, err := client.fetchOpenClawRowsPage(httpClient, endpoint, dataset, split, nextOffset, length)
+		page, err := client.fetchOpenClawRowsPage(client.requestContext(), httpClient, endpoint, dataset, split, nextOffset, length)
 		if err != nil {
 			return nil, err
 		}
@@ -793,7 +795,7 @@ func (client HuggingFaceBenchmarkClient) FetchSkillTrustBenchRows(dataset string
 	if rowsURL == "" {
 		rowsURL = skillTrustBenchRowsURL
 	}
-	raw, statusCode, err := fetchHuggingFaceRowsPage(httpClient, rowsURL)
+	raw, statusCode, err := fetchHuggingFaceRowsPage(client.requestContext(), httpClient, rowsURL)
 	if err != nil {
 		return nil, err
 	}
@@ -831,7 +833,14 @@ func (client HuggingFaceBenchmarkClient) FetchSkillTrustBenchRows(dataset string
 	return rows[offset:end], nil
 }
 
-func (client HuggingFaceBenchmarkClient) fetchOpenClawRowsPage(httpClient *http.Client, endpoint string, dataset string, split string, offset int, length int) ([]OpenClawBenchmarkRow, error) {
+func (client HuggingFaceBenchmarkClient) requestContext() context.Context {
+	if client.Context != nil {
+		return client.Context
+	}
+	return context.Background()
+}
+
+func (client HuggingFaceBenchmarkClient) fetchOpenClawRowsPage(ctx context.Context, httpClient *http.Client, endpoint string, dataset string, split string, offset int, length int) ([]OpenClawBenchmarkRow, error) {
 	values := url.Values{}
 	values.Set("dataset", dataset)
 	values.Set("config", openClawBenchmarkConfig)
@@ -839,7 +848,7 @@ func (client HuggingFaceBenchmarkClient) fetchOpenClawRowsPage(httpClient *http.
 	values.Set("offset", fmt.Sprintf("%d", offset))
 	values.Set("length", fmt.Sprintf("%d", length))
 	requestURL := endpoint + "?" + values.Encode()
-	raw, statusCode, err := fetchHuggingFaceRowsPage(httpClient, requestURL)
+	raw, statusCode, err := fetchHuggingFaceRowsPage(ctx, httpClient, requestURL)
 	if err != nil {
 		return nil, err
 	}
@@ -861,10 +870,16 @@ func (client HuggingFaceBenchmarkClient) fetchOpenClawRowsPage(httpClient *http.
 	return rows, nil
 }
 
-func fetchHuggingFaceRowsPage(httpClient *http.Client, requestURL string) ([]byte, int, error) {
+func fetchHuggingFaceRowsPage(ctx context.Context, httpClient *http.Client, requestURL string) ([]byte, int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var lastErr error
 	for attempt := 1; attempt <= huggingFaceRowsMaxAttempts; attempt++ {
-		raw, statusCode, headers, err := fetchHuggingFaceRowsPageOnce(httpClient, requestURL)
+		if err := ctx.Err(); err != nil {
+			return nil, 0, err
+		}
+		raw, statusCode, headers, err := fetchHuggingFaceRowsPageOnce(ctx, httpClient, requestURL)
 		if err == nil && !isRetriableHuggingFaceRowsStatus(statusCode) {
 			return raw, statusCode, nil
 		}
@@ -879,13 +894,21 @@ func fetchHuggingFaceRowsPage(httpClient *http.Client, requestURL string) ([]byt
 		if attempt == huggingFaceRowsMaxAttempts {
 			break
 		}
-		time.Sleep(huggingFaceRowsBackoff(attempt, headers))
+		select {
+		case <-ctx.Done():
+			return nil, 0, ctx.Err()
+		case <-time.After(huggingFaceRowsBackoff(attempt, headers)):
+		}
 	}
 	return nil, 0, lastErr
 }
 
-func fetchHuggingFaceRowsPageOnce(httpClient *http.Client, requestURL string) ([]byte, int, http.Header, error) {
-	response, err := httpClient.Get(requestURL)
+func fetchHuggingFaceRowsPageOnce(ctx context.Context, httpClient *http.Client, requestURL string) ([]byte, int, http.Header, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	response, err := httpClient.Do(request)
 	if err != nil {
 		return nil, 0, nil, err
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -103,6 +103,7 @@ type EnvRequirement struct {
 }
 
 type RunContext struct {
+	Context              context.Context
 	Env                  map[string]string
 	Now                  func() time.Time
 	CommandRunner        CommandRunner

--- a/internal/runner/submission_test.go
+++ b/internal/runner/submission_test.go
@@ -1,7 +1,9 @@
 package runner
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -219,6 +221,52 @@ func TestHuggingFaceBenchmarkClientRetriesRateLimitHTTPError(t *testing.T) {
 	}
 	if requests != 3 {
 		t.Fatalf("requests = %d, want 3", requests)
+	}
+}
+
+func TestHuggingFaceBenchmarkClientHonorsCancelDuringRetryBackoff(t *testing.T) {
+	withHuggingFaceRowsRetryDelay(t, 30*time.Second)
+
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"slow down"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	client := HuggingFaceBenchmarkClient{
+		Endpoint: server.URL,
+		Context:  ctx,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.FetchOpenClawRows("OpenClaw/clawhub-security-signals", "eval_holdout", 0, 1)
+		done <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first HuggingFace request did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("FetchOpenClawRows did not return after context cancel")
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

`clawscan benchmark` fetches HuggingFace dataset rows with retry backoff. That wait used `time.Sleep`, so a canceled context (Ctrl+C / SIGINT on the CLI path) could not interrupt the delay. After a 429 or 5xx, the process sat in backoff for up to 30s per attempt, even after cancel.

The hang was introduced in [PR #2](https://github.com/openclaw/clawscan/pull/2) (2026-06-25) when transient row-fetch retries were added.

## Evidence

```console
Red (unfixed, cancel during 30s backoff):
    FetchOpenClawRows did not return after context cancel

Green (patched):
$ go test -count=1 -v -run TestHuggingFaceBenchmarkClientHonorsCancelDuringRetryBackoff ./internal/runner/
=== RUN   TestHuggingFaceBenchmarkClientHonorsCancelDuringRetryBackoff
--- PASS: TestHuggingFaceBenchmarkClientHonorsCancelDuringRetryBackoff (0.00s)
PASS
ok  	github.com/openclaw/clawscan/internal/runner	0.185s
```

Cancel during backoff now returns `context.Canceled` immediately instead of waiting out the sleep.

## Real behavior proof
- **Behavior addressed:** HuggingFace row-fetch retry backoff stops when the request context is canceled, instead of finishing `time.Sleep`.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Go 1.26.5, clawscan worktree `/tmp/oc-impl-clawscan-hf-sleep` on `fix/hf-retry-context`.
- **Exact steps or command run after this patch:** `go test -count=1 -v -run TestHuggingFaceBenchmarkClientHonorsCancelDuringRetryBackoff ./internal/runner/`
- **Evidence after fix:** terminal output copied below.

```console
$ go test -count=1 -v -run TestHuggingFaceBenchmarkClientHonorsCancelDuringRetryBackoff ./internal/runner/
=== RUN   TestHuggingFaceBenchmarkClientHonorsCancelDuringRetryBackoff
--- PASS: TestHuggingFaceBenchmarkClientHonorsCancelDuringRetryBackoff (0.00s)
PASS
ok  	github.com/openclaw/clawscan/internal/runner	0.185s
```

- **Observed result after fix:** After the first 429, cancel unblocks the fetch and the error is `context.Canceled` (0.00s in the run above). Before the patch the same cancel left the call blocked past a 2s hang-guard.
- **What was not tested:** Live HuggingFace datasets-server 429s; archive download for SkillTrustBench materialization (different GET, no retry sleep).
