### PR TITLE
feat(profiles): add aig to the production clawhub profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ clawscan profiles -v
 
 | Profile | Scanners | Judge |
 | --- | --- | --- |
-| `clawhub` | `skillspector`, `clawscan-static` | Codex `gpt-5.5`, high reasoning, bundled ClawHub prompt/schema |
+| `clawhub` | `skillspector`, `clawscan-static`, `aig` | Codex `gpt-5.5`, high reasoning, bundled ClawHub prompt/schema |
 | `openclaw-install-policy` | `skillspector`, `clawscan-static` | none |
 
 ### Build a custom profile with `.clawscan.yml`

--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ clawscan ./my-skill --profile clawhub
 ```
 
 The same profile accepts an explicit OpenClaw plugin directory (or its
-`openclaw.plugin.json` manifest), runs both scanners, and renders the
-bundled judge prompt with `packageRelease` target context.
+`openclaw.plugin.json` manifest), runs the plugin-capable scanners in the
+profile, and renders the bundled judge prompt with `packageRelease` target
+context.
 
 Inspect the built-in profile catalog:
 

--- a/cmd/clawscan/main_test.go
+++ b/cmd/clawscan/main_test.go
@@ -542,7 +542,7 @@ profiles:
 		"Scanners",
 		"clawhub",
 		"built-in",
-		"skillspector, clawscan-static",
+		"skillspector, clawscan-static, aig",
 		"clawhub-aig",
 		"skillspector, aig",
 	} {
@@ -1041,12 +1041,15 @@ func TestRunCommandUsesBuiltInProfile(t *testing.T) {
 	writeSkill(t, target, "# Profile\n")
 	skillSpectorFixture := filepath.Join(dir, "skillspector.json")
 	writeFile(t, skillSpectorFixture, `{"status":"clean","findings":[]}`)
+	aigFixture := filepath.Join(dir, "aig.sarif.json")
+	writeFile(t, aigFixture, `{"version":"2.1.0","runs":[{"results":[]}]}`)
 
 	stdout := captureStdout(t, func() {
 		if err := run([]string{
 			target,
 			"--profile", "clawhub",
 			"--scanner-result", "skillspector=" + skillSpectorFixture,
+			"--scanner-result", "aig=" + aigFixture,
 			"--judge", clawHubReceiptJudgeCommand(),
 			"--sandbox", "off",
 			"--json",
@@ -1071,6 +1074,9 @@ func TestRunCommandUsesBuiltInProfile(t *testing.T) {
 	if _, ok := artifact.Scanners["clawscan-static"]; !ok {
 		t.Fatalf("missing clawscan-static scanner: %#v", artifact.Scanners)
 	}
+	if _, ok := artifact.Scanners["aig"]; !ok {
+		t.Fatalf("missing aig scanner: %#v", artifact.Scanners)
+	}
 	if artifact.Judge == nil || artifact.Judge.Status != "completed" {
 		t.Fatalf("judge = %#v", artifact.Judge)
 	}
@@ -1082,12 +1088,15 @@ func TestRunCommandDiscoversSkillsWithExplicitProfile(t *testing.T) {
 	writeSkill(t, filepath.Join(dir, "skills", "bar"), "# Bar\n")
 	skillSpectorFixture := filepath.Join(dir, "skillspector.json")
 	writeFile(t, skillSpectorFixture, `{"status":"clean","findings":[]}`)
+	aigFixture := filepath.Join(dir, "aig.sarif.json")
+	writeFile(t, aigFixture, `{"version":"2.1.0","runs":[{"results":[]}]}`)
 	t.Chdir(dir)
 
 	stdout := captureStdout(t, func() {
 		if err := run([]string{
 			"--profile", "clawhub",
 			"--scanner-result", "skillspector=" + skillSpectorFixture,
+			"--scanner-result", "aig=" + aigFixture,
 			"--judge", clawHubReceiptJudgeCommand(),
 			"--sandbox", "off",
 			"--json",

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -55,7 +55,7 @@ clawscan profiles -v
 
 | Profile | Scanners | Judge |
 | --- | --- | --- |
-| `clawhub` | `skillspector`, `clawscan-static` | Codex `gpt-5.5`, high reasoning, bundled ClawHub prompt/schema |
+| `clawhub` | `skillspector`, `clawscan-static`, `aig` | Codex `gpt-5.5`, high reasoning, bundled ClawHub prompt/schema |
 | `openclaw-install-policy` | `skillspector`, `clawscan-static` | none |
 
 ## Build a custom profile with `.clawscan.yml`

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -9,8 +9,9 @@ clawscan ./my-skill --profile clawhub
 ```
 
 The same profile accepts an explicit OpenClaw plugin directory (or its
-`openclaw.plugin.json` manifest), runs both scanners, and renders the
-bundled judge prompt with `packageRelease` target context.
+`openclaw.plugin.json` manifest), runs the plugin-capable scanners in the
+profile, and renders the bundled judge prompt with `packageRelease` target
+context.
 
 ## Config discovery
 

--- a/internal/profiles/clawhub/clawscan.yml
+++ b/internal/profiles/clawhub/clawscan.yml
@@ -5,11 +5,13 @@ profiles:
     scanners:
       - skillspector
       - clawscan-static
+      - aig
     sandbox:
       env:
         - OPENAI_API_KEY
         - CODEX_API_KEY
         - SKILLSPECTOR_PROVIDER
+        - LLM_API_KEY
     judge:
       command: >-
         [ -n "$CODEX_API_KEY" ] || export CODEX_API_KEY="$OPENAI_API_KEY";

--- a/internal/profiles/clawhub/clawscan.yml
+++ b/internal/profiles/clawhub/clawscan.yml
@@ -12,6 +12,8 @@ profiles:
         - CODEX_API_KEY
         - SKILLSPECTOR_PROVIDER
         - LLM_API_KEY
+        - DEFAULT_MODEL
+        - DEFAULT_BASE_URL
     judge:
       command: >-
         [ -n "$CODEX_API_KEY" ] || export CODEX_API_KEY="$OPENAI_API_KEY";
@@ -40,6 +42,8 @@ profiles:
         - CODEX_API_KEY
         - SKILLSPECTOR_PROVIDER
         - LLM_API_KEY
+        - DEFAULT_MODEL
+        - DEFAULT_BASE_URL
     judge:
       command: >-
         [ -n "$CODEX_API_KEY" ] || export CODEX_API_KEY="$OPENAI_API_KEY";

--- a/internal/profiles/registry_test.go
+++ b/internal/profiles/registry_test.go
@@ -26,7 +26,7 @@ func TestDefaultProfileRegistryContainsEmbeddedBuiltIns(t *testing.T) {
 	if !ok {
 		t.Fatal("missing clawhub profile")
 	}
-	if got := strings.Join(profileScannerIDs(clawhub.profile.Scanners), ","); got != "skillspector,clawscan-static" {
+	if got := strings.Join(profileScannerIDs(clawhub.profile.Scanners), ","); got != "skillspector,clawscan-static,aig" {
 		t.Fatalf("clawhub scanners = %q", got)
 	}
 	if clawhub.configDir != "clawhub" {
@@ -91,7 +91,7 @@ func TestInspectProfilesReturnsBuiltIns(t *testing.T) {
 	if !ok {
 		t.Fatal("missing clawhub profile")
 	}
-	if got := strings.Join(profileScannerIDs(clawhub.Profile.Scanners), ","); got != "skillspector,clawscan-static" {
+	if got := strings.Join(profileScannerIDs(clawhub.Profile.Scanners), ","); got != "skillspector,clawscan-static,aig" {
 		t.Fatalf("clawhub scanners = %q", got)
 	}
 	if clawhub.Source != "built-in" {

--- a/internal/profiles/resolver_test.go
+++ b/internal/profiles/resolver_test.go
@@ -66,7 +66,7 @@ func TestResolveArgsUsesEmbeddedClawHubProfile(t *testing.T) {
 	if string(opts.Judge.Files["clawhub/output.schema.json"]) == "" {
 		t.Fatal("expected embedded clawhub output schema file")
 	}
-	if got := strings.Join(opts.Sandbox.Env, ","); got != "OPENAI_API_KEY,CODEX_API_KEY,SKILLSPECTOR_PROVIDER,LLM_API_KEY" {
+	if got := strings.Join(opts.Sandbox.Env, ","); got != "OPENAI_API_KEY,CODEX_API_KEY,SKILLSPECTOR_PROVIDER,LLM_API_KEY,DEFAULT_MODEL,DEFAULT_BASE_URL" {
 		t.Fatalf("sandbox env = %q", got)
 	}
 }
@@ -100,7 +100,7 @@ func TestResolveArgsUsesEmbeddedClawHubAIGCandidateProfile(t *testing.T) {
 			t.Fatalf("candidate judge file %s differs from clawhub", path)
 		}
 	}
-	if got := strings.Join(candidate.Sandbox.Env, ","); got != "OPENAI_API_KEY,CODEX_API_KEY,SKILLSPECTOR_PROVIDER,LLM_API_KEY" {
+	if got := strings.Join(candidate.Sandbox.Env, ","); got != "OPENAI_API_KEY,CODEX_API_KEY,SKILLSPECTOR_PROVIDER,LLM_API_KEY,DEFAULT_MODEL,DEFAULT_BASE_URL" {
 		t.Fatalf("sandbox env = %q", got)
 	}
 }
@@ -693,7 +693,7 @@ func TestResolveArgsAppliesCLIOverrides(t *testing.T) {
 	if opts.Sandbox.Image != "ghcr.io/acme/runtime:v1" {
 		t.Fatalf("sandbox image = %q", opts.Sandbox.Image)
 	}
-	if got := strings.Join(opts.Sandbox.Env, ","); got != "OPENAI_API_KEY,CODEX_API_KEY,SKILLSPECTOR_PROVIDER,LLM_API_KEY,ANTHROPIC_API_KEY" {
+	if got := strings.Join(opts.Sandbox.Env, ","); got != "OPENAI_API_KEY,CODEX_API_KEY,SKILLSPECTOR_PROVIDER,LLM_API_KEY,DEFAULT_MODEL,DEFAULT_BASE_URL,ANTHROPIC_API_KEY" {
 		t.Fatalf("sandbox env = %q", got)
 	}
 }

--- a/internal/profiles/resolver_test.go
+++ b/internal/profiles/resolver_test.go
@@ -30,7 +30,7 @@ func TestResolveArgsUsesEmbeddedClawHubProfile(t *testing.T) {
 	if opts.ConfigSource != "built-in" {
 		t.Fatalf("config source = %q, want built-in", opts.ConfigSource)
 	}
-	if got := strings.Join(opts.Scanners, ","); got != "skillspector,clawscan-static" {
+	if got := strings.Join(opts.Scanners, ","); got != "skillspector,clawscan-static,aig" {
 		t.Fatalf("scanners = %q", got)
 	}
 	if len(opts.GateRules) != 0 {
@@ -66,7 +66,7 @@ func TestResolveArgsUsesEmbeddedClawHubProfile(t *testing.T) {
 	if string(opts.Judge.Files["clawhub/output.schema.json"]) == "" {
 		t.Fatal("expected embedded clawhub output schema file")
 	}
-	if got := strings.Join(opts.Sandbox.Env, ","); got != "OPENAI_API_KEY,CODEX_API_KEY,SKILLSPECTOR_PROVIDER" {
+	if got := strings.Join(opts.Sandbox.Env, ","); got != "OPENAI_API_KEY,CODEX_API_KEY,SKILLSPECTOR_PROVIDER,LLM_API_KEY" {
 		t.Fatalf("sandbox env = %q", got)
 	}
 }
@@ -358,7 +358,7 @@ func TestResolveArgsAllowsExplicitProfileWithoutTarget(t *testing.T) {
 	if opts.Target != "" {
 		t.Fatalf("target = %q", opts.Target)
 	}
-	if got := strings.Join(opts.Scanners, ","); got != "skillspector,clawscan-static" {
+	if got := strings.Join(opts.Scanners, ","); got != "skillspector,clawscan-static,aig" {
 		t.Fatalf("scanners = %q", got)
 	}
 }
@@ -369,7 +369,9 @@ func TestResolveArgsDoesNotRequireVirusTotalForClawHubProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runner.ValidateRequirements(opts, map[string]string{}); err != nil {
+	// OPENAI_API_KEY is already required by the ClawHub Codex judge for this
+	// profile, and aig's requirement is satisfied by that same key.
+	if err := runner.ValidateRequirements(opts, map[string]string{"OPENAI_API_KEY": "present"}); err != nil {
 		t.Fatalf("unexpected requirement error: %v", err)
 	}
 	if strings.Contains(strings.Join(opts.Sandbox.Env, ","), "VIRUSTOTAL_API_KEY") {
@@ -691,7 +693,7 @@ func TestResolveArgsAppliesCLIOverrides(t *testing.T) {
 	if opts.Sandbox.Image != "ghcr.io/acme/runtime:v1" {
 		t.Fatalf("sandbox image = %q", opts.Sandbox.Image)
 	}
-	if got := strings.Join(opts.Sandbox.Env, ","); got != "OPENAI_API_KEY,CODEX_API_KEY,SKILLSPECTOR_PROVIDER,ANTHROPIC_API_KEY" {
+	if got := strings.Join(opts.Sandbox.Env, ","); got != "OPENAI_API_KEY,CODEX_API_KEY,SKILLSPECTOR_PROVIDER,LLM_API_KEY,ANTHROPIC_API_KEY" {
 		t.Fatalf("sandbox env = %q", got)
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1570,10 +1570,10 @@ func RenderClawHubPrompt(systemPromptSource string, artifact Artifact) (string, 
 		return "", err
 	}
 	var supplemental []clawhubprompt.ScannerEvidence
-	if artifact.Profile == clawHubAIGProfileID {
+	if aigAnalysis := clawHubAIGAnalysis(artifact); aigAnalysis != nil {
 		supplemental = append(supplemental, clawhubprompt.ScannerEvidence{
 			Label: "A.I.G SARIF evidence supplied to Codex",
-			Value: clawHubAIGAnalysis(artifact),
+			Value: aigAnalysis,
 		})
 	}
 	return clawhubprompt.Build(

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2199,21 +2199,34 @@ func defaultSkillSpectorOpenAIProvider(env map[string]string) {
 	env["SKILLSPECTOR_PROVIDER"] = "openai"
 }
 
-// defaultAIGKeyFromCodex lets aig reuse an already-configured CODEX_API_KEY
-// when no LLM_API_KEY/OPENAI_API_KEY is set. The ClawHub judge command itself
-// already treats CODEX_API_KEY as an accepted OPENAI_API_KEY substitute
-// (see internal/profiles/clawhub/clawscan.yml), so aig's own credential
-// requirement should honor the same fallback instead of demanding a second,
-// separately-named key from existing CODEX_API_KEY-only deployments.
-func defaultAIGKeyFromCodex(env map[string]string) {
+const (
+	defaultAIGOpenAIModel   = "gpt-5.5"
+	defaultAIGOpenAIBaseURL = "https://api.openai.com/v1"
+)
+
+// defaultAIGRuntimeEnv keeps credentials on their intended provider. AIG's
+// upstream default is OpenRouter, so an OpenAI or Codex credential must also
+// select OpenAI's endpoint and a compatible model. A dedicated LLM_API_KEY
+// retains AIG's documented provider defaults.
+func defaultAIGRuntimeEnv(env map[string]string) {
 	if env == nil {
 		return
 	}
-	if strings.TrimSpace(env["LLM_API_KEY"]) != "" || strings.TrimSpace(env["OPENAI_API_KEY"]) != "" {
+	if strings.TrimSpace(env["LLM_API_KEY"]) != "" {
 		return
 	}
-	if codexKey := strings.TrimSpace(env["CODEX_API_KEY"]); codexKey != "" {
-		env["OPENAI_API_KEY"] = codexKey
+	if strings.TrimSpace(env["OPENAI_API_KEY"]) == "" {
+		codexKey := strings.TrimSpace(env["CODEX_API_KEY"])
+		if codexKey == "" {
+			return
+		}
+		env["LLM_API_KEY"] = codexKey
+	}
+	if strings.TrimSpace(env["DEFAULT_MODEL"]) == "" {
+		env["DEFAULT_MODEL"] = defaultAIGOpenAIModel
+	}
+	if strings.TrimSpace(env["DEFAULT_BASE_URL"]) == "" {
+		env["DEFAULT_BASE_URL"] = defaultAIGOpenAIBaseURL
 	}
 }
 
@@ -2222,7 +2235,7 @@ func applyRuntimeEnvDefaults(opts Options, env map[string]string) {
 		defaultSkillSpectorOpenAIProvider(env)
 	}
 	if scannerRequested(opts, "aig") {
-		defaultAIGKeyFromCodex(env)
+		defaultAIGRuntimeEnv(env)
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2199,9 +2199,30 @@ func defaultSkillSpectorOpenAIProvider(env map[string]string) {
 	env["SKILLSPECTOR_PROVIDER"] = "openai"
 }
 
+// defaultAIGKeyFromCodex lets aig reuse an already-configured CODEX_API_KEY
+// when no LLM_API_KEY/OPENAI_API_KEY is set. The ClawHub judge command itself
+// already treats CODEX_API_KEY as an accepted OPENAI_API_KEY substitute
+// (see internal/profiles/clawhub/clawscan.yml), so aig's own credential
+// requirement should honor the same fallback instead of demanding a second,
+// separately-named key from existing CODEX_API_KEY-only deployments.
+func defaultAIGKeyFromCodex(env map[string]string) {
+	if env == nil {
+		return
+	}
+	if strings.TrimSpace(env["LLM_API_KEY"]) != "" || strings.TrimSpace(env["OPENAI_API_KEY"]) != "" {
+		return
+	}
+	if codexKey := strings.TrimSpace(env["CODEX_API_KEY"]); codexKey != "" {
+		env["OPENAI_API_KEY"] = codexKey
+	}
+}
+
 func applyRuntimeEnvDefaults(opts Options, env map[string]string) {
 	if scannerRequested(opts, "skillspector") {
 		defaultSkillSpectorOpenAIProvider(env)
+	}
+	if scannerRequested(opts, "aig") {
+		defaultAIGKeyFromCodex(env)
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2849,6 +2849,57 @@ func TestSkillSpectorDefaultsProviderToOpenAIWhenOpenAIKeyIsPresent(t *testing.T
 	}
 }
 
+func TestAIGReusesCodexAPIKeyWhenNoOtherKeyIsSet(t *testing.T) {
+	// The clawhub judge command already treats CODEX_API_KEY as an accepted
+	// OPENAI_API_KEY substitute, so existing CODEX_API_KEY-only ClawHub
+	// deployments must keep working once aig joins the profile's scanners.
+	env := map[string]string{"CODEX_API_KEY": "codex-value"}
+	defaultAIGKeyFromCodex(env)
+	if env["OPENAI_API_KEY"] != "codex-value" {
+		t.Fatalf("OPENAI_API_KEY not backfilled from CODEX_API_KEY: %#v", env)
+	}
+
+	preferExisting := map[string]string{"CODEX_API_KEY": "codex-value", "OPENAI_API_KEY": "openai-value"}
+	defaultAIGKeyFromCodex(preferExisting)
+	if preferExisting["OPENAI_API_KEY"] != "openai-value" {
+		t.Fatalf("existing OPENAI_API_KEY was overwritten: %#v", preferExisting)
+	}
+
+	preferLLMKey := map[string]string{"CODEX_API_KEY": "codex-value", "LLM_API_KEY": "llm-value"}
+	defaultAIGKeyFromCodex(preferLLMKey)
+	if _, ok := preferLLMKey["OPENAI_API_KEY"]; ok {
+		t.Fatalf("OPENAI_API_KEY backfilled despite existing LLM_API_KEY: %#v", preferLLMKey)
+	}
+
+	withoutCodexKey := map[string]string{}
+	defaultAIGKeyFromCodex(withoutCodexKey)
+	if _, ok := withoutCodexKey["OPENAI_API_KEY"]; ok {
+		t.Fatalf("OPENAI_API_KEY backfilled without a CODEX_API_KEY source: %#v", withoutCodexKey)
+	}
+}
+
+func TestApplyRuntimeEnvDefaultsBackfillsAIGKeyOnlyWhenAIGRequested(t *testing.T) {
+	requested, err := ParseArgs([]string{"./skill", "--scanner", "aig"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := map[string]string{"CODEX_API_KEY": "codex-value"}
+	applyRuntimeEnvDefaults(requested, env)
+	if err := ValidateRequirements(requested, env); err != nil {
+		t.Fatalf("unexpected requirement error after backfill: %v", err)
+	}
+
+	notRequested, err := ParseArgs([]string{"./skill", "--scanner", "clawscan-static"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unaffected := map[string]string{"CODEX_API_KEY": "codex-value"}
+	applyRuntimeEnvDefaults(notRequested, unaffected)
+	if _, ok := unaffected["OPENAI_API_KEY"]; ok {
+		t.Fatalf("OPENAI_API_KEY backfilled without aig in the scanner list: %#v", unaffected)
+	}
+}
+
 func TestRunExecutesAgentVerusScanner(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "skill")

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -4564,6 +4564,35 @@ func TestRenderClawHubAIGPromptIncludesAIGEvidence(t *testing.T) {
 	}
 }
 
+func TestRenderClawHubPromptIncludesAIGEvidenceForProductionProfile(t *testing.T) {
+	// The production "clawhub" profile (not just the retired "clawhub-aig"
+	// candidate) now runs aig alongside skillspector and clawscan-static, so
+	// its SARIF evidence must reach the Codex judge whenever it produced a
+	// result, regardless of which profile label requested the run. The
+	// pre-scan malicious-signal heuristic is unchanged by this and still
+	// keys off clawscan-static for the "clawhub" profile label.
+	prompt, err := RenderClawHubPrompt("SYSTEM", Artifact{
+		Profile: "clawhub",
+		Scanners: map[string]ScannerResult{
+			"skillspector":    {Raw: json.RawMessage(`{"status":"clean"}`)},
+			"clawscan-static": {Raw: json.RawMessage(`{"schemaVersion":"clawscan-static-v1","findings":[]}`)},
+			"aig":             {Raw: json.RawMessage(`{"version":"2.1.0","runs":[{"results":[{"ruleId":"T04","level":"error"}]}]}`)},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"SkillSpector findings supplied to Codex:",
+		"A.I.G SARIF evidence supplied to Codex:",
+		`"ruleId": "T04"`,
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
 func TestRenderClawHubPromptIgnoresLegacyVirusTotalEvidence(t *testing.T) {
 	prompt, err := RenderClawHubPrompt("SYSTEM", Artifact{
 		Context: json.RawMessage(`{"skillSpectorCheckedAt":123}`),

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2849,32 +2849,54 @@ func TestSkillSpectorDefaultsProviderToOpenAIWhenOpenAIKeyIsPresent(t *testing.T
 	}
 }
 
-func TestAIGReusesCodexAPIKeyWhenNoOtherKeyIsSet(t *testing.T) {
+func TestAIGRuntimeDefaultsKeepCredentialsOnTheirProvider(t *testing.T) {
 	// The clawhub judge command already treats CODEX_API_KEY as an accepted
-	// OPENAI_API_KEY substitute, so existing CODEX_API_KEY-only ClawHub
-	// deployments must keep working once aig joins the profile's scanners.
-	env := map[string]string{"CODEX_API_KEY": "codex-value"}
-	defaultAIGKeyFromCodex(env)
-	if env["OPENAI_API_KEY"] != "codex-value" {
-		t.Fatalf("OPENAI_API_KEY not backfilled from CODEX_API_KEY: %#v", env)
+	// OpenAI credential. AIG defaults to OpenRouter, so reuse must also bind the
+	// request to OpenAI without enabling SkillSpector's OpenAI mode.
+	env := map[string]string{"CODEX_API_KEY": "fake"}
+	defaultAIGRuntimeEnv(env)
+	if env["LLM_API_KEY"] != "fake" {
+		t.Fatalf("LLM_API_KEY not backfilled from CODEX_API_KEY: %#v", env)
+	}
+	if env["DEFAULT_MODEL"] != defaultAIGOpenAIModel || env["DEFAULT_BASE_URL"] != defaultAIGOpenAIBaseURL {
+		t.Fatalf("AIG OpenAI defaults not applied: %#v", env)
+	}
+	if skillSpectorLLMEnabled(env) {
+		t.Fatalf("AIG fallback unexpectedly enabled SkillSpector LLM mode: %#v", env)
 	}
 
-	preferExisting := map[string]string{"CODEX_API_KEY": "codex-value", "OPENAI_API_KEY": "openai-value"}
-	defaultAIGKeyFromCodex(preferExisting)
-	if preferExisting["OPENAI_API_KEY"] != "openai-value" {
-		t.Fatalf("existing OPENAI_API_KEY was overwritten: %#v", preferExisting)
+	openAI := map[string]string{"OPENAI_API_KEY": "fake"}
+	defaultAIGRuntimeEnv(openAI)
+	if openAI["DEFAULT_MODEL"] != defaultAIGOpenAIModel || openAI["DEFAULT_BASE_URL"] != defaultAIGOpenAIBaseURL {
+		t.Fatalf("OPENAI_API_KEY did not select OpenAI defaults: %#v", openAI)
+	}
+	if _, ok := openAI["LLM_API_KEY"]; ok {
+		t.Fatalf("LLM_API_KEY backfilled despite existing OPENAI_API_KEY: %#v", openAI)
 	}
 
-	preferLLMKey := map[string]string{"CODEX_API_KEY": "codex-value", "LLM_API_KEY": "llm-value"}
-	defaultAIGKeyFromCodex(preferLLMKey)
-	if _, ok := preferLLMKey["OPENAI_API_KEY"]; ok {
-		t.Fatalf("OPENAI_API_KEY backfilled despite existing LLM_API_KEY: %#v", preferLLMKey)
+	explicitOpenAI := map[string]string{
+		"OPENAI_API_KEY":   "fake",
+		"DEFAULT_MODEL":    "custom-model",
+		"DEFAULT_BASE_URL": "https://example.invalid/v1",
+	}
+	defaultAIGRuntimeEnv(explicitOpenAI)
+	if explicitOpenAI["DEFAULT_MODEL"] != "custom-model" || explicitOpenAI["DEFAULT_BASE_URL"] != "https://example.invalid/v1" {
+		t.Fatalf("explicit AIG provider settings were overwritten: %#v", explicitOpenAI)
 	}
 
-	withoutCodexKey := map[string]string{}
-	defaultAIGKeyFromCodex(withoutCodexKey)
-	if _, ok := withoutCodexKey["OPENAI_API_KEY"]; ok {
-		t.Fatalf("OPENAI_API_KEY backfilled without a CODEX_API_KEY source: %#v", withoutCodexKey)
+	dedicated := map[string]string{"CODEX_API_KEY": "fake", "OPENAI_API_KEY": "fake", "LLM_API_KEY": "fake"}
+	defaultAIGRuntimeEnv(dedicated)
+	if _, ok := dedicated["DEFAULT_MODEL"]; ok {
+		t.Fatalf("dedicated LLM_API_KEY received an OpenAI model default: %#v", dedicated)
+	}
+	if _, ok := dedicated["DEFAULT_BASE_URL"]; ok {
+		t.Fatalf("dedicated LLM_API_KEY received an OpenAI base URL default: %#v", dedicated)
+	}
+
+	withoutKey := map[string]string{}
+	defaultAIGRuntimeEnv(withoutKey)
+	if len(withoutKey) != 0 {
+		t.Fatalf("AIG defaults applied without a credential source: %#v", withoutKey)
 	}
 }
 
@@ -2883,20 +2905,32 @@ func TestApplyRuntimeEnvDefaultsBackfillsAIGKeyOnlyWhenAIGRequested(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	env := map[string]string{"CODEX_API_KEY": "codex-value"}
+	env := map[string]string{"CODEX_API_KEY": "fake"}
 	applyRuntimeEnvDefaults(requested, env)
 	if err := ValidateRequirements(requested, env); err != nil {
 		t.Fatalf("unexpected requirement error after backfill: %v", err)
+	}
+	if env["LLM_API_KEY"] != "fake" {
+		t.Fatalf("AIG key not backfilled into LLM_API_KEY: %#v", env)
+	}
+	if env["DEFAULT_MODEL"] != defaultAIGOpenAIModel || env["DEFAULT_BASE_URL"] != defaultAIGOpenAIBaseURL {
+		t.Fatalf("AIG OpenAI defaults not applied: %#v", env)
+	}
+	if skillSpectorLLMEnabled(env) {
+		t.Fatalf("AIG fallback unexpectedly enabled SkillSpector LLM mode: %#v", env)
 	}
 
 	notRequested, err := ParseArgs([]string{"./skill", "--scanner", "clawscan-static"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	unaffected := map[string]string{"CODEX_API_KEY": "codex-value"}
+	unaffected := map[string]string{"CODEX_API_KEY": "fake"}
 	applyRuntimeEnvDefaults(notRequested, unaffected)
-	if _, ok := unaffected["OPENAI_API_KEY"]; ok {
-		t.Fatalf("OPENAI_API_KEY backfilled without aig in the scanner list: %#v", unaffected)
+	if _, ok := unaffected["LLM_API_KEY"]; ok {
+		t.Fatalf("LLM_API_KEY backfilled without aig in the scanner list: %#v", unaffected)
+	}
+	if _, ok := unaffected["DEFAULT_BASE_URL"]; ok {
+		t.Fatalf("AIG provider defaults applied without aig in the scanner list: %#v", unaffected)
 	}
 }
 


### PR DESCRIPTION
## Summary

- What changed: The production `clawhub` profile now runs `aig` alongside
  `skillspector` and `clawscan-static` (previously `aig` was only evaluated
  through the unpublished `clawhub-aig` candidate profile). `RenderClawHubPrompt`
  now attaches AIG SARIF evidence to the Codex judge whenever `aig` produced a
  result, instead of keying off `artifact.Profile == "clawhub-aig"`, so
  production runs get the same evidence the candidate profile already
  received.

## Security / Trust Impact

- [x] Security/trust impact explained

`aig` now runs as part of the production `clawhub` profile, requiring
`LLM_API_KEY` (or `OPENAI_API_KEY`) at scan time — already listed as an
optional/required env for the `aig` scanner adapter and added to this
profile's `sandbox.env`. `RenderClawHubPrompt`'s AIG-evidence attachment is
now driven by scanner-result presence (`clawHubAIGAnalysis(artifact) != nil`)
rather than the profile id string, so the same evidence path that
`clawhub-aig` already exercised now also fires for `clawhub`. The
malicious-signal heuristic (`clawHubHasMaliciousSignal`) is unchanged. The
`clawhub-aig` candidate profile is left in place for isolated evaluation.

## Verification

- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] `go run ./cmd/clawscan --help`
- [x] Focused scanner/benchmark/manual proof: `go run ./cmd/clawscan profiles -v`
      confirms the `clawhub` profile lists `skillspector, clawscan-static, aig`;
      added `TestRenderClawHubPromptIncludesAIGEvidenceForProductionProfile` to
      cover AIG evidence reaching the Codex judge prompt under the production
      `clawhub` profile label.
