### PR TITLE
fix(runner): cap HuggingFace Retry-After backoff at 30s

### DIFF
--- a/internal/runner/benchmark.go
+++ b/internal/runner/benchmark.go
@@ -929,11 +929,11 @@ func isRetriableHuggingFaceRowsStatus(statusCode int) bool {
 func huggingFaceRowsBackoff(attempt int, headers http.Header) time.Duration {
 	if retryAfter := headers.Get("Retry-After"); retryAfter != "" {
 		if seconds, err := strconv.Atoi(retryAfter); err == nil && seconds >= 0 {
-			return time.Duration(seconds) * time.Second
+			return min(time.Duration(seconds)*time.Second, 30*time.Second)
 		}
 		if retryAt, err := http.ParseTime(retryAfter); err == nil {
 			if delay := time.Until(retryAt); delay > 0 {
-				return delay
+				return min(delay, 30*time.Second)
 			}
 		}
 	}

--- a/internal/runner/submission_test.go
+++ b/internal/runner/submission_test.go
@@ -270,6 +270,19 @@ func TestHuggingFaceBenchmarkClientHonorsCancelDuringRetryBackoff(t *testing.T) 
 	}
 }
 
+func TestHuggingFaceRowsBackoffCapsRetryAfter(t *testing.T) {
+	got := huggingFaceRowsBackoff(1, http.Header{"Retry-After": []string{"3600"}})
+	if got != 30*time.Second {
+		t.Fatalf("Retry-After 3600 = %s, want 30s", got)
+	}
+
+	future := time.Now().UTC().Add(2 * time.Hour).Format(http.TimeFormat)
+	got = huggingFaceRowsBackoff(1, http.Header{"Retry-After": []string{future}})
+	if got != 30*time.Second {
+		t.Fatalf("Retry-After HTTP-date %q = %s, want 30s", future, got)
+	}
+}
+
 func withHuggingFaceRowsRetryDelay(t *testing.T, delay time.Duration) {
 	t.Helper()
 	previous := huggingFaceRowsRetryDelay


### PR DESCRIPTION
## What Problem This Solves

`clawscan benchmark clawhub-security-signals` fetches HuggingFace dataset rows and retries on 429/5xx. `huggingFaceRowsBackoff` honors `Retry-After` as integer seconds or an HTTP-date with no ceiling, while the quadratic fallback is already capped at 30s.

The public CLI builds `HuggingFaceBenchmarkClient` with a nil Context, so `requestContext()` is `context.Background()` and the retry `select` never expires. A 429 with `Retry-After: 3600` blocks the process for one hour per attempt (up to five waits). This change caps `Retry-After` at the same 30s ceiling. It does not add a process-wide signal context.

The uncapped header path was introduced in [#3](https://github.com/openclaw/clawscan/pull/3) (2026-06-25). [#46](https://github.com/openclaw/clawscan/pull/46) made the wait cancelable when a context is set; it did not cap the delay.

## Evidence

Red (unfixed `huggingFaceRowsBackoff`):

```console
$ go test -count=1 -timeout 30s -v -run TestHuggingFaceRowsBackoffCapsRetryAfter ./internal/runner/
=== RUN   TestHuggingFaceRowsBackoffCapsRetryAfter
    submission_test.go:276: Retry-After 3600 = 1h0m0s, want 30s
--- FAIL: TestHuggingFaceRowsBackoffCapsRetryAfter (0.00s)
FAIL
FAIL    github.com/openclaw/clawscan/internal/runner    0.248s
FAIL
```

Green (after the 30s cap):

```console
$ go test -count=1 -timeout 30s -v -run TestHuggingFaceRowsBackoffCapsRetryAfter ./internal/runner/
=== RUN   TestHuggingFaceRowsBackoffCapsRetryAfter
--- PASS: TestHuggingFaceRowsBackoffCapsRetryAfter (0.00s)
PASS
ok      github.com/openclaw/clawscan/internal/runner    0.263s
```

`Retry-After: 3600` and an HTTP-date two hours ahead both return 30s. The quadratic fallback path is unchanged.

## Real behavior proof

- **Behavior or issue addressed:** HuggingFace row-fetch `Retry-After` delays (integer seconds and HTTP-date) are capped at 30s, matching the existing fallback ceiling, so a 429 cannot stall `clawscan benchmark` for an hour per attempt.
- **Real environment tested:** macOS 26.6.2 (Darwin 25.6.0 arm64), go1.27.0 darwin/arm64, checkout `/tmp/oc-pr-clawscan-F003` on `fix/f003-huggingface-retry-after-cap`.
- **Exact steps or command run after this patch:**

  ```bash
  go test -count=1 -timeout 30s -v -run TestHuggingFaceRowsBackoffCapsRetryAfter ./internal/runner/
  ```

- **Evidence after fix:** terminal output from the patched tree:

  ```console
  $ go test -count=1 -timeout 30s -v -run TestHuggingFaceRowsBackoffCapsRetryAfter ./internal/runner/
  === RUN   TestHuggingFaceRowsBackoffCapsRetryAfter
  --- PASS: TestHuggingFaceRowsBackoffCapsRetryAfter (0.00s)
  PASS
  ok      github.com/openclaw/clawscan/internal/runner    0.263s
  ```

- **Observed result after fix:** `Retry-After: 3600` is 30s (was 1h). An HTTP-date two hours ahead is also 30s. The helper no longer returns a multi-hour wait.
- **What was not tested:** A live HuggingFace 429 with a long `Retry-After` header. Network fetch of `datasets-server.huggingface.co` during this change.

Command: `go test -count=1 -timeout 30s -v -run TestHuggingFaceRowsBackoffCapsRetryAfter ./internal/runner/`

Observed: unfixed delay was `1h0m0s` for `Retry-After: 3600`; patched delay is `30s` for both `3600` and a future HTTP-date.

Expected: both header forms cap at 30s.

Time: 11:07:34 PDT (2026-08-29 18:07:34 UTC)

Date: 2026-08-29

Environment: macOS 26.6.2, Darwin 25.6.0 arm64, go1.27.0 darwin/arm64
